### PR TITLE
Add Aurora Ribbons scene (state 10) with input mapping, HUD and docs

### DIFF
--- a/Music_Visualizer_CK/AuroraRibbonsScene.pde
+++ b/Music_Visualizer_CK/AuroraRibbonsScene.pde
@@ -1,0 +1,238 @@
+// Aurora Ribbons Scene — state 10
+// Atmospheric triangle-strip curtains driven by low/mid/high energy.
+
+class AuroraRibbonsScene {
+  float drift = 0.0;
+  float wind = 0.35;
+  float ribbonLengthScale = 1.0;
+  float hueOffset = 190;
+  float turbulence = 1.0;
+  float beatFlash = 0.0;
+  float beatSplit = 0.0;
+
+  // Adaptive band normalization (auto-gain): keeps the scene expressive
+  // across songs with very different loudness/arrangement.
+  float lowFloor = 0.4, lowCeil = 7.0;
+  float midFloor = 0.3, midCeil = 6.0;
+  float highFloor = 0.2, highCeil = 5.0;
+
+  // Curated palette presets: hue shift + sat/bri scaling
+  int paletteIndex = 0;
+  String[] paletteNames = {"Arctic", "Neon", "Sunset", "Void"};
+  float[] paletteHueShift = {0, 28, -32, 180};
+  float[] paletteSatMult  = {0.70, 1.15, 0.95, 0.55};
+  float[] paletteBriMult  = {1.05, 1.20, 1.10, 0.78};
+
+  AuroraRibbonsScene() {}
+
+  void applyController(Controller c) {
+    float lx = map(c.lx, 0, width, -1, 1);
+    float rx = map(c.rx, 0, width, -1, 1);
+    float ry = map(c.ry, 0, height, -1, 1);
+
+    // L stick ↔ controls wind advection
+    wind = map(lx, -1, 1, -2.2, 2.2);
+    // R stick ↕ controls vertical ribbon length
+    ribbonLengthScale = constrain(map(ry, -1, 1, 1.65, 0.55), 0.45, 2.2);
+    // R stick ↔ controls turbulence/detail
+    turbulence = constrain(map(rx, -1, 1, 0.35, 2.2), 0.2, 2.4);
+
+    if (c.a_just_pressed) triggerFlash();
+    if (c.y_just_pressed) hueOffset = (hueOffset + 24) % 360;
+  }
+
+  void triggerFlash() {
+    beatFlash = 1.0;
+    beatSplit = 1.0;
+  }
+
+  void cyclePalette() {
+    paletteIndex = (paletteIndex + 1) % paletteNames.length;
+  }
+
+  void adjustLength(float delta) {
+    ribbonLengthScale = constrain(ribbonLengthScale + delta, 0.45, 2.2);
+  }
+
+  void adjustTurbulence(float delta) {
+    turbulence = constrain(turbulence + delta, 0.2, 2.4);
+  }
+
+  void adjustHue(float delta) {
+    hueOffset = (hueOffset + delta + 360) % 360;
+  }
+
+  String[] getCodeLines() {
+    return new String[] {
+      "=== Aurora Ribbons ===",
+      "",
+      "// Layered TRIANGLE_STRIP curtains with noise-driven sway",
+      "sway = (noise(x*freq + drift, t*speed) - 0.5) * width",
+      "length = base_len * ribbon_length_scale * (1 + low_norm*0.32)",
+      "",
+      "// Adaptive normalizer tracks each song's dynamic range",
+      "norm = clamp((raw - floor) / max(0.001, ceil-floor), 0, 1)",
+      "",
+      "// Beat onset -> flash + curtain split from center",
+      "x += sign(x-center) * beat_split * split_strength",
+      "beat_flash *= 0.90, beat_split *= 0.86"
+    };
+  }
+
+  void drawScene() {
+    float lowRaw = bandEnergy(0.00, 0.20);
+    float midRaw = bandEnergy(0.20, 0.55);
+    float highRaw = bandEnergy(0.55, 1.00);
+
+    float low = normalizeAdaptive(lowRaw,  0);
+    float mid = normalizeAdaptive(midRaw,  1);
+    float high = normalizeAdaptive(highRaw, 2);
+
+    if (audio.beat.isOnset()) {
+      triggerFlash();
+      drift += 0.35;
+    }
+    beatFlash *= 0.90;
+    beatSplit *= 0.86;
+
+    drift += 0.0035 * wind * (1.0 + high * 0.9);
+
+    colorMode(HSB, 360, 255, 255, 255);
+    noStroke();
+
+    float pSat = paletteSatMult[paletteIndex];
+    float pBri = paletteBriMult[paletteIndex];
+    float pHue = paletteHueShift[paletteIndex];
+
+    // dark sky gradient-ish wash
+    for (int i = 0; i < 7; i++) {
+      float yy = map(i, 0, 6, 0, height);
+      float bgHue = (hueOffset + pHue + 220 + i * 2) % 360;
+      float bgSat = constrain((170 - i * 18) * pSat * 0.8, 0, 255);
+      float bgBri = constrain((20 + i * 8) * pBri, 0, 255);
+      fill(bgHue, bgSat, bgBri, 255);
+      rect(0, yy, width, height / 7.0 + 1);
+    }
+
+    blendMode(ADD);
+    int layers = 6;
+    for (int layer = 0; layer < layers; layer++) {
+      float layerMix = layer / float(max(1, layers - 1));
+      float len = (height * (0.22 + layerMix * 0.12)) * ribbonLengthScale * (1.0 + low * 0.32);
+      float spacing = max(8, width / 70.0);
+      float freq = (0.004 + layerMix * 0.003) * turbulence;
+      float speed = 0.35 + layerMix * 0.6 + high * 0.35;
+      float swayAmp = (34 + layer * 12 + high * 22) * turbulence;
+      float splitStrength = (10 + layer * 8) * beatSplit;
+
+      beginShape(TRIANGLE_STRIP);
+      for (float x = 0; x <= width + spacing; x += spacing) {
+        float nx = x * freq;
+        float n1 = noise(nx + drift * speed, frameCount * 0.0035 + layer * 13.0);
+        float n2 = noise(nx + drift * speed + 33.0, frameCount * 0.0045 + layer * 19.0);
+        float sway = (n1 - 0.5) * swayAmp;
+        float centerSide = (x < width * 0.5) ? -1.0 : 1.0;
+
+        float topY = map(n2, 0, 1, -20, 45 + layer * 14);
+        float bottomY = topY + len + (n1 - 0.5) * (65 + low * 35.0);
+
+        float hue = (hueOffset + pHue + layer * 17 + sin(frameCount * 0.01 + x * 0.015) * 16 + mid * 26) % 360;
+        float sat = constrain((170 + 65 * (1.0 - layerMix)) * pSat, 0, 255);
+        float bri = constrain((145 + layer * 14 + high * 90) * pBri, 0, 255);
+        float aTop = 42 + layer * 10 + beatFlash * 65;
+        float aBot = 8 + layer * 3 + beatFlash * 20;
+
+        float split = centerSide * splitStrength;
+
+        fill(hue, sat, bri, aTop);
+        vertex(x + sway + split, topY);
+        fill(hue, sat * 0.8, bri * 0.8, aBot);
+        vertex(x + sway * 0.35 + split * 0.38, bottomY);
+      }
+      endShape();
+    }
+
+    drawMist(high, pHue, pSat, pBri);
+
+    // beat veil
+    if (beatFlash > 0.01) {
+      blendMode(SCREEN);
+      fill((hueOffset + pHue + 120) % 360, 40, 255, 80 * beatFlash);
+      rect(0, 0, width, height);
+    }
+
+    blendMode(BLEND);
+    colorMode(RGB, 255);
+
+    drawSongNameOnScreen(config.SONG_NAME, width / 2.0, height - 5);
+    drawHud(low, mid, high);
+  }
+
+  void drawMist(float highNorm, float pHue, float pSat, float pBri) {
+    int pCount = int(24 + highNorm * 42);
+    for (int i = 0; i < pCount; i++) {
+      float t = frameCount * 0.004 + i * 0.17;
+      float x = noise(i * 2.7, t + drift * 0.2) * width;
+      float y = height * (0.22 + noise(i * 5.1, t * 0.9) * 0.72);
+      float r = 1.2 + noise(i * 7.3, t * 1.1) * (2.0 + highNorm * 5.5);
+      float hue = (hueOffset + pHue + 170 + noise(i * 9.7, t * 0.6) * 45) % 360;
+      float sat = constrain((90 + highNorm * 120) * pSat, 0, 255);
+      float bri = constrain((130 + highNorm * 105) * pBri, 0, 255);
+      float a = 10 + highNorm * 45;
+      fill(hue, sat, bri, a);
+      ellipse(x, y, r * 2.0, r * 2.0);
+    }
+  }
+
+  float normalizeAdaptive(float raw, int band) {
+    float floor, ceil;
+    if (band == 0) {
+      lowFloor = lerp(lowFloor, min(lowFloor, raw), 0.035);
+      lowCeil  = lerp(lowCeil,  max(lowCeil * 0.997, raw), 0.04);
+      floor = lowFloor;
+      ceil = lowCeil;
+    } else if (band == 1) {
+      midFloor = lerp(midFloor, min(midFloor, raw), 0.035);
+      midCeil  = lerp(midCeil,  max(midCeil * 0.997, raw), 0.04);
+      floor = midFloor;
+      ceil = midCeil;
+    } else {
+      highFloor = lerp(highFloor, min(highFloor, raw), 0.035);
+      highCeil  = lerp(highCeil,  max(highCeil * 0.997, raw), 0.04);
+      floor = highFloor;
+      ceil = highCeil;
+    }
+
+    float n = (raw - floor) / max(0.001, ceil - floor);
+    return constrain(n, 0, 1);
+  }
+
+  float bandEnergy(float startNorm, float endNorm) {
+    int n = max(1, audio.fft.avgSize());
+    int s = constrain(int(n * startNorm), 0, n - 1);
+    int e = constrain(int(n * endNorm), s + 1, n);
+    float total = 0;
+    for (int i = s; i < e; i++) total += audio.fft.getAvg(i);
+    return total / max(1, e - s);
+  }
+
+  void drawHud(float low, float mid, float high) {
+    pushStyle();
+      float ts = 11 * uiScale();
+      float lh = ts * 1.3;
+      fill(0, 125);
+      noStroke();
+      rectMode(CORNER);
+      rect(8, 8, 390 * uiScale(), 8 + lh * 6.2);
+      fill(255);
+      textSize(ts);
+      textAlign(LEFT, TOP);
+      text("Scene: Aurora Ribbons", 12, 12);
+      text("low / mid / high (norm): " + nf(low, 1, 2) + " / " + nf(mid, 1, 2) + " / " + nf(high, 1, 2), 12, 12 + lh);
+      text("wind: " + nf(wind, 1, 2) + "  len: " + nf(ribbonLengthScale, 1, 2) + "x", 12, 12 + lh * 2);
+      text("turbulence: " + nf(turbulence, 1, 2) + "  hue: " + nf(hueOffset, 1, 1), 12, 12 + lh * 3);
+      text("palette: " + paletteNames[paletteIndex] + "  split: " + nf(beatSplit, 1, 2), 12, 12 + lh * 4);
+      text("A flash  Y hue step  K palette  [ ] turbulence  -/= length", 12, 12 + lh * 5);
+    popStyle();
+  }
+}

--- a/Music_Visualizer_CK/Music_Visualizer_CK.pde
+++ b/Music_Visualizer_CK/Music_Visualizer_CK.pde
@@ -21,6 +21,7 @@ PrismCodexScene prismCodex;
 TableTennisScene tableTennis;
 WormScene wormScene;
 FFTWormScene fftWorm;
+AuroraRibbonsScene auroraRibbons;
 PFont monoFont;
 
 BezierHeart bezier_heart_0;
@@ -371,6 +372,7 @@ void setup() {
   tableTennis = new TableTennisScene();
   wormScene = new WormScene();
   fftWorm   = new FFTWormScene();
+  auroraRibbons = new AuroraRibbonsScene();
   monoFont = createFont("Monospaced", 15, true);
   // Dev shortcut: if .devscene exists in the sketch dir, start on that scene.
   // e.g.  echo 6 > Music_Visualizer_CK/.devscene
@@ -663,8 +665,8 @@ void keyPressed() {
   if (key == 'i' || key == 'I') {
     config.DRAW_INNER_DIAMONDS = !config.DRAW_INNER_DIAMONDS;
   }
-  if (key >= '1' && key <= '9') {
-    int newState = (int) key - 48;
+  if ((key >= '1' && key <= '9') || key == '0') {
+    int newState = (key == '0') ? 10 : ((int) key - 48);
     // Only allow switching to active scenes (3 and 9 are disabled)
     if (_sceneOrderIndex(newState) >= 0 || newState == SCENE_ORDER[0]) {
       boolean inRotation = false;
@@ -728,6 +730,17 @@ void keyPressed() {
     if (key == 'a' || key == 'A') particleFountain.nudgeOrigin(-10, 0);
     if (key == 's' || key == 'S') particleFountain.nudgeOrigin(0, 10);
     if (key == 'd' || key == 'D') particleFountain.nudgeOrigin(10, 0);
+  }
+  // Aurora ribbons keys (state 10 only)
+  if (config.STATE == 10 && auroraRibbons != null) {
+    if (key == '[') auroraRibbons.adjustTurbulence(-0.05);
+    if (key == ']') auroraRibbons.adjustTurbulence(0.05);
+    if (key == '-' || key == '_') auroraRibbons.adjustLength(-0.05);
+    if (key == '=' || key == '+') auroraRibbons.adjustLength(0.05);
+    if (key == 'h' || key == 'H') auroraRibbons.adjustHue(-7);
+    if (key == 'j' || key == 'J') auroraRibbons.adjustHue(7);
+    if (key == 'k' || key == 'K') auroraRibbons.cyclePalette();
+    if (key == ' ') auroraRibbons.triggerFlash();
   }
   if (key == '`') {
     config.SHOW_CODE = !config.SHOW_CODE;
@@ -979,6 +992,11 @@ public void getUserInput(boolean usingController) {
     fftWorm.applyController(controller);
   }
 
+  // aurora ribbons
+  if (config.STATE == 10 && auroraRibbons != null) {
+    auroraRibbons.applyController(controller);
+  }
+
   // map controller sticks to Shapes3DScene parameters for live tuning
   if (config.STATE == 3 && shapes3D != null) {
     // controller.* values are mapped to screen coords (0..width or 0..height) by Controller
@@ -1051,7 +1069,7 @@ int previous_state = -1;
 // ── Active scene list ─────────────────────────────────────────────────────────
 // Only these scenes are reachable via LB/RB cycling. Scenes 3 and 9 are kept
 // in the codebase but excluded from rotation for now.
-final int[] SCENE_ORDER = {1, 3, 9, 8, 2, 4, 5, 6, 7};
+final int[] SCENE_ORDER = {1, 3, 9, 8, 2, 4, 5, 6, 7, 10};
 
 int _sceneOrderIndex(int state) {
   for (int i = 0; i < SCENE_ORDER.length; i++) {
@@ -1396,6 +1414,12 @@ void draw() {
     fftWorm.drawScene();
     addFPSToTitleBar();
     break;
+  case 10:
+    getUserInput(config.USING_CONTROLLER);
+    auroraRibbons.drawScene();
+    if (config.SHOW_CODE) drawCodeOverlay(auroraRibbons.getCodeLines());
+    addFPSToTitleBar();
+    break;
   }
 
   // ── Per-scene controls HUD (` to toggle) ────────────────────────────────────
@@ -1494,6 +1518,11 @@ void drawControlsHUD() {
     "9: L ↕           pulse sensitivity",
     "9: Y             cycle bg mode",
     "9: A             manual pulse",
+    "10: L ↔          wind drift",
+    "10: R ↕          ribbon length",
+    "10: R ↔          turbulence",
+    "10: A / Y        flash / hue shift",
+    "10: K / Space    palette / flash",
     "",
     "=== KEYBOARD ===",
     "0–9              switch scene",

--- a/documentation/controller_mappings.md
+++ b/documentation/controller_mappings.md
@@ -81,6 +81,17 @@ All scenes support a controller (Xbox-style via GameControlPlus).
 | R Stick ↕ | Drift speed |
 | A | Trigger beat glow |
 
+### Scene 10 — Aurora Ribbons
+| Control | Action |
+|---------|--------|
+| L Stick ↔ | Wind drift direction/speed |
+| R Stick ↕ | Ribbon length |
+| R Stick ↔ | Turbulence/detail |
+| A | Manual flash |
+| Y | Hue offset step |
+
+Keyboard (state 10): `K` cycles palette, `Space` triggers manual flash, `[ ]` turbulence, `- / =` length, `H / J` hue.
+
 ## Technical notes
 
 - The Xbox controller on Linux exposes LT and RT as a **single combined "z" axis** via GameControlPlus (`getSlider("z")`). Values: `-1.0` = LT fully pressed, `+1.0` = RT fully pressed.

--- a/documentation/scene_list.md
+++ b/documentation/scene_list.md
@@ -5,7 +5,7 @@ Scenes are cycled with **LB / RB** on the controller, or **number keys 1–9** o
 The active scene order is defined by `SCENE_ORDER` in `Music_Visualizer_CK.pde`:
 
 ```java
-final int[] SCENE_ORDER = {1, 3, 9, 8, 2, 4, 5, 6, 7};
+final int[] SCENE_ORDER = {1, 3, 9, 8, 2, 4, 5, 6, 7, 10};
 ```
 
 | Key | State | Scene | File |
@@ -19,8 +19,12 @@ final int[] SCENE_ORDER = {1, 3, 9, 8, 2, 4, 5, 6, 7};
 | 5   | 5     | Oscilloscope | OscilloscopeScene.pde |
 | 6   | 6     | Table Tennis | TableTennisScene.pde |
 | 7   | 7     | Prism Codex | PrismCodexScene.pde |
+| 0   | 10    | Aurora Ribbons | AuroraRibbonsScene.pde |
 
-States 0 and 10 exist in code (Halo2Logo at 0 or similar) but are not in SCENE_ORDER and are unreachable via normal navigation.
+State 0 still exists as a legacy placeholder. State 10 (Aurora Ribbons) is in SCENE_ORDER and reachable via LB/RB cycle and keyboard `0`.
 
 > **Note:** Keyboard keys map to the *position* in SCENE_ORDER, not the state number directly.
 > Key `1` → SCENE_ORDER[0] = state 1, key `2` → SCENE_ORDER[1] = state 3, etc.
+
+
+Keyboard note: key `0` maps to state `10` for Aurora Ribbons.


### PR DESCRIPTION
### Motivation
- Introduce a new audio-reactive "Aurora Ribbons" visual to the sketch that produces layered triangle-strip curtains driven by low/mid/high band energy and supports live tuning via controller and keyboard.
- Make the scene reachable via scene rotation and keyboard so it can be used alongside the other visual states.

### Description
- Added `Music_Visualizer_CK/AuroraRibbonsScene.pde` implementing `AuroraRibbonsScene` with adaptive band normalization, noise-driven sway, palette presets, beat flash/split, and public tuning methods (`applyController`, `adjustTurbulence`, `adjustLength`, `adjustHue`, `cyclePalette`, `triggerFlash`, `getCodeLines`).
- Integrated the scene into the main sketch by declaring `auroraRibbons`, instantiating it in `setup()`, calling `auroraRibbons.applyController(controller)` from `getUserInput()`, and adding a `case 10` branch in `draw()` to render the scene and its `getCodeLines()` overlay.
- Updated input handling so numeric keyboard support includes `0` mapping to state `10`, added keyboard tuning handlers for state 10 in `keyPressed()` (turbulence, length, hue, palette, flash/space), and added controller mappings for the scene in the HUD.
- Updated scene ordering and documentation by appending `10` to `SCENE_ORDER` and editing `documentation/controller_mappings.md` and `documentation/scene_list.md` to describe controls and the new scene.

### Testing
- No automated tests are present in the repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c0aaf824832b9effdbfba0b4245c)