### PR TITLE
feat: TableTennis3DScene (scene 25) + 2D TableTennis QoL fixes

### DIFF
--- a/Music_Visualizer_CK/Music_Visualizer_CK.pde
+++ b/Music_Visualizer_CK/Music_Visualizer_CK.pde
@@ -10,7 +10,7 @@ Config config;
 Audio audio;
 Controller controller;
 IScene[] scenes;
-final int SCENE_COUNT = 25;
+final int SCENE_COUNT = 26;
 int previousState = -1;
 
 AudioAnalyser analyzer;
@@ -215,21 +215,26 @@ void collectSongs(java.io.File dir, ArrayList<String> songs) {
   }
 }
 
-String fileSelected(File selection) {
+void fileSelected(File selection) {
   if (selection == null) {
     log_to_stdo("No file selected. Window might have been closed/cancelled");
-    return "";
-  } else {
-    log_to_stdo("File selected: " + selection.getAbsolutePath());
-    config.SONG_TO_VISUALIZE = selection.getAbsolutePath();
-    // Scan the parent directory so n/N can navigate nearby songs
-    if (config.songList.size() == 0) {
-      collectSongs(selection.getParentFile(), config.songList);
-    }
-    config.currentSongIndex = config.songList.indexOf(selection.getAbsolutePath());
-    if (config.currentSongIndex < 0) config.currentSongIndex = 0;
+    return;
   }
-  return selection.getAbsolutePath();
+  String path = selection.getAbsolutePath();
+  log_to_stdo("File selected: " + path);
+  config.SONG_TO_VISUALIZE = path;
+  config.SONG_NAME = getSongNameFromFilePath(path, config.OS_TYPE);
+  // Always rescan parent folder so n/N works with the new location
+  config.songList.clear();
+  collectSongs(selection.getParentFile(), config.songList);
+  config.currentSongIndex = config.songList.indexOf(path);
+  if (config.currentSongIndex < 0) config.currentSongIndex = 0;
+
+  // At runtime (audio already exists) load immediately.
+  // At startup the setSongToVisualize() while-loop picks up SONG_TO_VISUALIZE instead.
+  if (audio != null) {
+    loadSongByPath(path);
+  }
 }
 
 String discoverOperatingSystem() {
@@ -313,6 +318,7 @@ void setup() {
   scenes[22] = new CyberGridScene();
   scenes[23] = new RecursiveMandalaScene();
   scenes[24] = new KaleidoscopeScene();
+  scenes[25] = new TableTennis3DScene();
 
   // Initialise smoke test runner after all scenes exist
   if (SMOKE_TEST_MODE) {
@@ -389,6 +395,7 @@ void keyPressed() {
   if (key == 's' || key == 'S') toggleSongPlaying();
   if (key == 'n') nextSong();
   if (key == 'N') shuffleSong();
+  if (key == 'o' || key == 'O') selectInput("Select song to visualize", "fileSelected");
   if (key == 'l' || key == 'L') config.LOGGING_ENABLED = !config.LOGGING_ENABLED;
   if (key == '`') config.SHOW_CODE = !config.SHOW_CODE;
   if (key == 'g' || key == 'G') config.BLOOM_ENABLED = !config.BLOOM_ENABLED;
@@ -527,7 +534,7 @@ public void getUserInput() {
 // in the codebase but excluded from rotation for now.
 // Fan-favourite scenes, in display order. Only these are reachable via
 // LB/RB cycling or keyboard number keys. Add a scene number here to re-enable it.
-final int[] SCENE_ORDER = {1, 4, 6, 7, 13, 14, 17, 18, 19, 23, 24};
+final int[] SCENE_ORDER = {1, 4, 6, 25, 7, 13, 14, 17, 18, 19, 23, 24};
 
 int _sceneOrderIndex(int state) {
   for (int i = 0; i < SCENE_ORDER.length; i++) {
@@ -748,7 +755,8 @@ void drawCodeOverlay(String[] lines) {
 
 void addFPSToTitleBar() {
   if (frameCount % 100 == 0) {
-    surface.setTitle("fps: " + int(frameRate) + " | " + config.TITLE_BAR);
+    surface.setTitle("fps: " + int(frameRate) + " | scene: " + config.STATE
+      + " | " + config.SONG_TO_VISUALIZE);
   }
 }
 
@@ -771,6 +779,13 @@ void drawSongNameOnScreen(PGraphics pg, String song_name, float nameLocationX, f
   
   pg.fill(255);
   pg.text(song_name, nameLocationX, nameLocationY);
+
+  // Small path line below song name for easy debugging
+  pg.textSize(11 * uiScale());
+  pg.fill(0);
+  pg.text(config.SONG_TO_VISUALIZE, nameLocationX + 1, nameLocationY + 18 * uiScale() + 1);
+  pg.fill(180, 180, 180, 180);
+  pg.text(config.SONG_TO_VISUALIZE, nameLocationX, nameLocationY + 18 * uiScale());
 }
 
 void mouseClicked() {

--- a/Music_Visualizer_CK/TableTennis3DScene.pde
+++ b/Music_Visualizer_CK/TableTennis3DScene.pde
@@ -1,0 +1,552 @@
+// Table Tennis 3D Scene — state 25
+//
+// Extends TableTennisScene: inherits all physics, rules, AI, scoring,
+// beat-glow, power shots, and bass breathing.
+//
+// Adds Z-axis shot variation: each paddle hit gives the ball a random
+// lateral (Z) velocity. Ball bounces off the table's Z edges.
+// Racket shapes: oval face (flattened sphere) + wooden handle.
+
+class TableTennis3DScene extends TableTennisScene {
+
+  // ── orbit camera ──────────────────────────────────────────────────────────
+  float camAzim   =  0.15;    // horizontal angle around table (radians)
+  float camElev   =  0.42;    // vertical tilt (radians; 0=horizontal, PI/2=straight down)
+  float camRadius = 950;      // distance from orbit centre
+  float shake     =  0;
+
+  // ── table dimensions ──────────────────────────────────────────────────────
+  final float TABLE_DEPTH = 680;   // Z extent of the table
+  final float PADDLE_D    = 18;    // racket face thickness (X axis, thin)
+  final float PADDLE_Z    = 130;   // racket face Z width (bat-sized)
+
+  // ── Z physics (supplementary — ball Z is 0 in parent) ────────────────────
+  float ballZ      = 0;
+  float ballVZ     = 0;
+  int   prevRallyCount = 0;
+
+  // ── paddle Z positions (3D only — parent only tracks X/Y) ────────────────
+  float leftPaddleZ  = 0;
+  float rightPaddleZ = 0;
+
+  // ── 3D trail (includes Z) ─────────────────────────────────────────────────
+  ArrayList<PVector> trail3D = new ArrayList<PVector>();
+
+  TableTennis3DScene() {
+    super();
+  }
+
+  // ── main draw ─────────────────────────────────────────────────────────────
+
+  void drawScene(PGraphics pg) {
+    pg.background(10, 28, 10);
+
+    float bass = 0, mid = 0;
+    for (int i = 0;  i < 8;  i++) bass += analyzer.spectrum[i];
+    for (int i = 8;  i < 24; i++) mid  += analyzer.spectrum[i];
+    bass /= 8.0;
+    mid  /= 16.0;
+
+    if (analyzer.isBeat) onBeat(bass, mid);
+    impactFlash *= 0.82;
+    pointFlash  *= 0.88;
+    beatGlow    *= 0.93;
+    powerFlash  *= 0.85;
+    bassSmooth   = lerp(bassSmooth, bass, 0.15);
+    powerReady   = beatGlow > 0.4;
+    shake       *= 0.80;
+    if (powerFlash > 0.7) shake = powerFlash * 7;
+
+    // Physics — inherited 2D physics + our Z layer
+    updatePaddleTargets();
+    movePaddles();
+    updatePhysics();
+    updateZPhysics();
+
+    // Build the 3D trail (replaces parent's 2D trail in rendering)
+    trail3D.add(new PVector(ballX, ballY, ballZ));
+    if (trail3D.size() > MAX_TRAIL) trail3D.remove(0);
+
+    // Power-shot zoom: temporarily shrink radius
+    float radius = camRadius - powerFlash * 80;
+
+    // Orbit centre — middle of the table/rally area
+    float cx = width / 2.0;
+    float cy = tableY - 60;    // slightly above the table surface
+    float cz = 0;
+
+    // Spherical → Cartesian (Y-down P3D convention: elevation raises the eye = decreases Y)
+    float shakeX = shake > 0.1 ? random(-shake, shake) : 0;
+    float shakeY = shake > 0.1 ? random(-shake, shake) * 0.3 : 0;
+    float eyeX = cx + radius * cos(camElev) * sin(camAzim) + shakeX;
+    float eyeY = cy - radius * sin(camElev)                + shakeY;
+    float eyeZ = cz + radius * cos(camElev) * cos(camAzim);
+
+    pg.camera(eyeX, eyeY, eyeZ, cx, cy, cz, 0, 1, 0);
+    pg.perspective(PI / 3.0, (float)pg.width / pg.height, 10, 8000);
+
+    // Lighting
+    pg.ambientLight(25, 55, 25);
+    pg.directionalLight(160, 200, 160, 0.2, 1.0, -0.4);
+    float bl = 80 + beatGlow * 175;
+    pg.pointLight((int)(bl * 0.85), (int)bl, (int)(bl * 0.5), ballX, ballY, ballZ);
+    if (powerFlash > 0.05)
+      pg.pointLight(255, 210, 60, ballX, ballY, ballZ);
+
+    drawEnvironmentFloor(pg);
+    drawTable(pg);
+    drawTrail(pg);
+    drawPaddles(pg);
+    drawBall(pg);
+    drawEnvironmentWalls(pg);
+
+    // Reset to screen-space for 2D HUD
+    pg.camera();
+    pg.perspective();
+    pg.noLights();
+    pg.hint(DISABLE_DEPTH_TEST);
+    drawScore(pg);
+    drawHUD(pg);
+    drawSongNameOnScreen(pg, config.SONG_NAME, pg.width / 2.0, pg.height - 5);
+    pg.hint(ENABLE_DEPTH_TEST);
+  }
+
+  // ── Z physics ─────────────────────────────────────────────────────────────
+
+  void updateZPhysics() {
+    // During serve drop, drift everything smoothly back to centre
+    if (inServeDrop) {
+      ballZ        = lerp(ballZ, 0, 0.06);
+      ballVZ      *= 0.88;
+      leftPaddleZ  = lerp(leftPaddleZ,  0, 0.08);
+      rightPaddleZ = lerp(rightPaddleZ, 0, 0.08);
+      prevRallyCount = 0;
+      return;
+    }
+
+    // Detect a new paddle hit (rallyCount just increased)
+    if (rallyCount > prevRallyCount) {
+      // Power shots get stronger lateral angle
+      float maxZ = powerReady ? 7.0 : 4.5;
+      ballVZ = random(-maxZ, maxZ);
+    }
+    // Point scored — rally restarted
+    if (rallyCount == 0 && prevRallyCount > 0) {
+      ballZ  = 0;
+      ballVZ = 0;
+      trail3D.clear();
+    }
+    prevRallyCount = rallyCount;
+
+    ballVZ *= 0.994;
+    ballZ  += ballVZ;
+
+    // Bounce off Z table edges
+    float zEdge = TABLE_DEPTH / 2.0 - BALL_RADIUS * 2;
+    if (ballZ > zEdge) {
+      ballZ  =  zEdge;
+      ballVZ *= -0.65;
+    } else if (ballZ < -zEdge) {
+      ballZ  = -zEdge;
+      ballVZ *= -0.65;
+    }
+
+    // Paddle Z tracking — receiving paddle follows ball Z, other returns to centre
+    float zLerpSpeed = 0.06;
+    if (ballVX < 0) {
+      // Ball heading left — left paddle is the receiver
+      leftPaddleZ  = lerp(leftPaddleZ,  ballZ, zLerpSpeed);
+      rightPaddleZ = lerp(rightPaddleZ, 0,     zLerpSpeed * 0.5);
+    } else {
+      // Ball heading right — right paddle is the receiver
+      rightPaddleZ = lerp(rightPaddleZ, ballZ, zLerpSpeed);
+      leftPaddleZ  = lerp(leftPaddleZ,  0,     zLerpSpeed * 0.5);
+    }
+  }
+
+  // Override collision to add Z gating — parent only checks X/Y.
+  // Ball must be within the paddle's Z half-extent to register a hit.
+  void checkPaddleCollision(boolean isLeft, float paddleX, float paddleY) {
+    float pz = isLeft ? leftPaddleZ : rightPaddleZ;
+    if (abs(ballZ - pz) > PADDLE_Z / 2.0 + BALL_RADIUS) return;
+    super.checkPaddleCollision(isLeft, paddleX, paddleY);
+  }
+
+  // ── environment (ground + enclosure box) ─────────────────────────────────
+
+  // Shared box dimensions
+  final float ENV_HW  = 1400;   // half-width  (X)
+  final float ENV_HD  = 600;    // half-depth  (Z)
+  final float ENV_TOP = -400;   // ceiling Y
+  final float ENV_BOT_OFFSET = 260; // how far below tableY the floor sits
+
+  void drawEnvironmentFloor(PGraphics pg) {
+    float cx   = width / 2.0;
+    float yBot = tableY + ENV_BOT_OFFSET;
+
+    pg.pushStyle();
+    pg.noStroke();
+
+    // Solid floor slab
+    pg.fill(12, 28, 12);
+    pg.pushMatrix();
+    pg.translate(cx, yBot + 3, 0);
+    pg.box(ENV_HW * 2, 6, ENV_HD * 2);
+    pg.popMatrix();
+
+    // Grid on floor — drawn as 3D lines
+    pg.noLights();
+    pg.stroke(0, 90, 0, 90);
+    pg.strokeWeight(1);
+    float step = 140;
+    for (float gx = cx - ENV_HW; gx <= cx + ENV_HW + 1; gx += step) {
+      pg.line(gx, yBot, -ENV_HD, gx, yBot, ENV_HD);
+    }
+    for (float gz = -ENV_HD; gz <= ENV_HD + 1; gz += step) {
+      pg.line(cx - ENV_HW, yBot, gz, cx + ENV_HW, yBot, gz);
+    }
+    pg.noStroke();
+    pg.lights();
+
+    pg.popStyle();
+  }
+
+  void drawEnvironmentWalls(PGraphics pg) {
+    float cx   = width / 2.0;
+    float yTop = ENV_TOP;
+    float yBot = tableY + ENV_BOT_OFFSET;
+    float xL   = cx - ENV_HW;
+    float xR   = cx + ENV_HW;
+    float zN   =  ENV_HD;   // near (toward viewer at +Z)
+    float zF   = -ENV_HD;   // far
+
+    pg.pushStyle();
+    pg.noStroke();
+    pg.noLights();
+    pg.blendMode(ADD);
+
+    // Four side walls — very faint blue tint
+    pg.fill(30, 60, 100, 18);
+
+    // Near wall
+    pg.beginShape(QUADS);
+    pg.vertex(xL, yTop, zN); pg.vertex(xR, yTop, zN);
+    pg.vertex(xR, yBot, zN); pg.vertex(xL, yBot, zN);
+    pg.endShape();
+
+    // Far wall
+    pg.beginShape(QUADS);
+    pg.vertex(xL, yTop, zF); pg.vertex(xR, yTop, zF);
+    pg.vertex(xR, yBot, zF); pg.vertex(xL, yBot, zF);
+    pg.endShape();
+
+    // Left wall
+    pg.beginShape(QUADS);
+    pg.vertex(xL, yTop, zF); pg.vertex(xL, yTop, zN);
+    pg.vertex(xL, yBot, zN); pg.vertex(xL, yBot, zF);
+    pg.endShape();
+
+    // Right wall
+    pg.beginShape(QUADS);
+    pg.vertex(xR, yTop, zF); pg.vertex(xR, yTop, zN);
+    pg.vertex(xR, yBot, zN); pg.vertex(xR, yBot, zF);
+    pg.endShape();
+
+    // Ceiling — even fainter
+    pg.fill(20, 40, 70, 10);
+    pg.beginShape(QUADS);
+    pg.vertex(xL, yTop, zF); pg.vertex(xR, yTop, zF);
+    pg.vertex(xR, yTop, zN); pg.vertex(xL, yTop, zN);
+    pg.endShape();
+
+    // Edge lines — slightly brighter so the box reads as a solid structure
+    pg.stroke(60, 120, 200, 55);
+    pg.strokeWeight(1.5);
+    // Vertical edges
+    pg.line(xL, yTop, zN,  xL, yBot, zN);
+    pg.line(xR, yTop, zN,  xR, yBot, zN);
+    pg.line(xL, yTop, zF,  xL, yBot, zF);
+    pg.line(xR, yTop, zF,  xR, yBot, zF);
+    // Top edges
+    pg.line(xL, yTop, zN,  xR, yTop, zN);
+    pg.line(xL, yTop, zF,  xR, yTop, zF);
+    pg.line(xL, yTop, zF,  xL, yTop, zN);
+    pg.line(xR, yTop, zF,  xR, yTop, zN);
+    // Bottom edges
+    pg.line(xL, yBot, zN,  xR, yBot, zN);
+    pg.line(xL, yBot, zF,  xR, yBot, zF);
+    pg.line(xL, yBot, zF,  xL, yBot, zN);
+    pg.line(xR, yBot, zF,  xR, yBot, zN);
+
+    pg.noStroke();
+    pg.blendMode(BLEND);
+    pg.lights();
+    pg.popStyle();
+  }
+
+  // ── 3D table ──────────────────────────────────────────────────────────────
+
+  void drawTable(PGraphics pg) {
+    float th    = 18;
+    float halfD = TABLE_DEPTH / 2.0;
+    float tw    = width * 0.88;
+    float tx    = width / 2.0;
+
+    pg.pushStyle();
+    pg.noStroke();
+
+    // Main surface
+    pg.fill(0, 110, 0);
+    pg.pushMatrix();
+    pg.translate(tx, tableY + th / 2.0, 0);
+    pg.box(tw, th, TABLE_DEPTH);
+    pg.popMatrix();
+
+    // Side frame rails
+    pg.fill(0, 75, 0);
+    pg.pushMatrix();
+    pg.translate(tx - tw / 2.0, tableY + th / 2.0, 0);
+    pg.box(12, th + 4, TABLE_DEPTH + 4);
+    pg.popMatrix();
+    pg.pushMatrix();
+    pg.translate(tx + tw / 2.0, tableY + th / 2.0, 0);
+    pg.box(12, th + 4, TABLE_DEPTH + 4);
+    pg.popMatrix();
+
+    // White line markings — drawn without lights so they read bright white
+    pg.noLights();
+    pg.fill(255, 255, 255, 220);
+    // Left edge line
+    pg.pushMatrix();
+    pg.translate(tx - tw / 2.0, tableY - 1, 0);
+    pg.box(3, 3, TABLE_DEPTH);
+    pg.popMatrix();
+    // Right edge line
+    pg.pushMatrix();
+    pg.translate(tx + tw / 2.0, tableY - 1, 0);
+    pg.box(3, 3, TABLE_DEPTH);
+    pg.popMatrix();
+    // Near end line
+    pg.pushMatrix();
+    pg.translate(tx, tableY - 1, -halfD);
+    pg.box(tw, 3, 3);
+    pg.popMatrix();
+    // Far end line
+    pg.pushMatrix();
+    pg.translate(tx, tableY - 1, halfD);
+    pg.box(tw, 3, 3);
+    pg.popMatrix();
+    // Centre line — runs the full Z length, prominent white
+    pg.fill(255, 255, 255, 255);
+    pg.pushMatrix();
+    pg.translate(tx, tableY - 2, 0);
+    pg.box(4, 4, TABLE_DEPTH);
+    pg.popMatrix();
+    pg.lights();
+
+    // Net — spanning full table depth
+    pg.fill(230, 230, 230, 220);
+    pg.pushMatrix();
+    pg.translate(tx, tableY - NET_H / 2.0, 0);
+    pg.box(6, NET_H, TABLE_DEPTH + 16);
+    pg.popMatrix();
+    // Net posts
+    pg.fill(160, 160, 160);
+    pg.pushMatrix();
+    pg.translate(tx, tableY - NET_H / 2.0, -(halfD + 8));
+    pg.box(14, NET_H + 8, 14);
+    pg.popMatrix();
+    pg.pushMatrix();
+    pg.translate(tx, tableY - NET_H / 2.0, halfD + 8);
+    pg.box(14, NET_H + 8, 14);
+    pg.popMatrix();
+
+    pg.popStyle();
+  }
+
+  // ── 3D paddles (rackets) ──────────────────────────────────────────────────
+
+  void drawPaddles(PGraphics pg) {
+    float lx      = leftPaddleX  + leftLungeX;
+    float rx      = rightPaddleX - rightLungeX;
+    float breathe = bassSmooth * 18;
+    float lh      = PADDLE_H + breathe;
+    float rh      = PADDLE_H + breathe;
+    float faceR   = PADDLE_Z * 0.46 + breathe * 0.25;   // oval radius breathes with bass
+    float lpz = leftPaddleZ;
+    float rpz = rightPaddleZ;
+
+    pg.pushStyle();
+    pg.noStroke();
+
+    // ── Beat-glow aura on the receiving paddle ────────────────────────────
+    if (beatGlow > 0.05) {
+      boolean leftActive = ballVX < 0;
+      float ax = leftActive ? lx : rx;
+      float ay = leftActive ? leftPaddleY : rightPaddleY;
+      float az = leftActive ? lpz : rpz;
+      float ah = leftActive ? lh : rh;
+      pg.colorMode(HSB, 360, 255, 255, 255);
+      float hue = powerReady ? 45 : 200;
+      pg.noLights();
+      pg.blendMode(ADD);
+      for (int ring = 3; ring >= 1; ring--) {
+        float sp = ring * 14 * beatGlow;
+        pg.fill((int)hue, 220, 255, (int)(beatGlow * 55 / ring));
+        pg.pushMatrix();
+        pg.translate(ax, ay, az);
+        pg.scale(PADDLE_D * 0.5 / faceR, 1.0, 1.0);
+        pg.sphere(faceR + sp);
+        pg.popMatrix();
+      }
+      pg.blendMode(BLEND);
+      pg.colorMode(RGB, 255);
+      pg.lights();
+    }
+
+    // ── Power-shot burst ─────────────────────────────────────────────────
+    if (powerFlash > 0.05) {
+      pg.noLights();
+      pg.blendMode(ADD);
+      pg.fill(255, 200, 50, (int)(powerFlash * 70));
+      float burstR = powerFlash * 80;
+      pg.pushMatrix(); pg.translate(lx, leftPaddleY,  lpz); pg.sphere(burstR); pg.popMatrix();
+      pg.pushMatrix(); pg.translate(rx, rightPaddleY, rpz); pg.sphere(burstR); pg.popMatrix();
+      pg.blendMode(BLEND);
+      pg.lights();
+    }
+
+    // ── Impact flash ─────────────────────────────────────────────────────
+    if (impactFlash > 0.05) {
+      pg.noLights();
+      pg.fill(255, 255, 255, (int)(impactFlash * 90));
+      pg.pushMatrix(); pg.translate(lx, leftPaddleY,  lpz); pg.scale(PADDLE_D * 0.5 / faceR, 1.0, 1.0); pg.sphere(faceR + 14); pg.popMatrix();
+      pg.pushMatrix(); pg.translate(rx, rightPaddleY, rpz); pg.scale(PADDLE_D * 0.5 / faceR, 1.0, 1.0); pg.sphere(faceR + 14); pg.popMatrix();
+      pg.lights();
+    }
+
+    // ── Left racket — red face ────────────────────────────────────────────
+    pg.fill(200, 35, 35);
+    drawRacket(pg, lx, leftPaddleY, lpz, faceR);
+
+    // ── Right racket — blue face ──────────────────────────────────────────
+    pg.fill(35, 35, 200);
+    drawRacket(pg, rx, rightPaddleY, rpz, faceR);
+
+    // ── Serve indicator ───────────────────────────────────────────────────
+    pg.noLights();
+    pg.fill(255, 220, 0, 200);
+    pg.pushMatrix();
+    pg.translate(leftServes ? lx : rx, tableY - 160, leftServes ? lpz : rpz);
+    pg.sphere(9);
+    pg.popMatrix();
+    pg.lights();
+
+    pg.popStyle();
+  }
+
+  // Draws one racket at (px, py, 0): oval face (flattened sphere) + wooden handle.
+  // Caller sets pg.fill() for the face colour before calling.
+  void drawRacket(PGraphics pg, float px, float py, float pz, float faceR) {
+    float faceY   = py - PADDLE_H * 0.08;
+    float handleH = PADDLE_H * 0.50;
+    float handleW = PADDLE_Z * 0.21;
+    float handleY = faceY + faceR + handleH * 0.52 + 3;
+
+    // Oval face — scale a sphere to make it thin in X
+    pg.pushMatrix();
+    pg.translate(px, faceY, pz);
+    pg.scale(PADDLE_D * 0.5 / faceR, 1.0, 1.0);
+    pg.sphere(faceR);
+    pg.popMatrix();
+
+    // Handle — wood grain colour
+    pg.fill(135, 78, 28);
+    pg.pushMatrix();
+    pg.translate(px, handleY, pz);
+    pg.box(PADDLE_D, handleH, handleW);
+    pg.popMatrix();
+  }
+
+  // ── 3D ball ───────────────────────────────────────────────────────────────
+
+  void drawBall(PGraphics pg) {
+    pg.pushStyle();
+    pg.colorMode(HSB, 360, 255, 255, 255);
+    pg.noStroke();
+
+    float gf = max(impactFlash, powerFlash);
+    if (gf > 0.05) {
+      pg.noLights();
+      pg.blendMode(ADD);
+      pg.fill((int)ballHue, 200, 255, (int)(gf * 75));
+      pg.pushMatrix();
+      pg.translate(ballX, ballY, ballZ);
+      pg.sphere(BALL_RADIUS * 4.5 * gf);
+      pg.popMatrix();
+      pg.blendMode(BLEND);
+      pg.lights();
+    }
+
+    pg.fill((int)ballHue, 160, 255);
+    pg.pushMatrix();
+    pg.translate(ballX, ballY, ballZ);
+    pg.sphere(BALL_RADIUS);
+    pg.popMatrix();
+
+    pg.colorMode(RGB, 255);
+    pg.popStyle();
+  }
+
+  // ── camera control ───────────────────────────────────────────────────────
+
+  // Left stick Y → zoom.  Right stick XY → orbit azimuth / elevation.
+  // X/Y buttons → ball speed (inherited behaviour kept on those buttons).
+  void applyController(Controller c) {
+    float ly = map(c.ly, 0, height, -1, 1);
+    if (abs(ly) > 0.15) camRadius = constrain(camRadius + ly * 12, 350, 2200);
+
+    float rx = map(c.rx, 0, width,  -1, 1);
+    float ry = map(c.ry, 0, height, -1, 1);
+    if (abs(rx) > 0.15) camAzim += rx * 0.030;
+    if (abs(ry) > 0.15) camElev  = constrain(camElev + ry * 0.020, 0.08, PI / 2 - 0.05);
+
+    // Speed from parent mapping (X=slower, Y=faster)
+    if (c.x_just_pressed) adjustSpeed(-0.1);
+    if (c.y_just_pressed) adjustSpeed( 0.1);
+  }
+
+  // a/d → orbit left/right  |  w/e → tilt up/down  |  z/x → zoom
+  // All other keys forwarded to parent (speed ,/. gravity +/- magnus [/])
+  void handleKey(char k) {
+    if      (k == 'a' || k == 'A') camAzim -= 0.12;
+    else if (k == 'd' || k == 'D') camAzim += 0.12;
+    else if (k == 'w' || k == 'W') camElev  = constrain(camElev + 0.10, 0.08, PI / 2 - 0.05);
+    else if (k == 'e' || k == 'E') camElev  = constrain(camElev - 0.10, 0.08, PI / 2 - 0.05);
+    else if (k == 'z' || k == 'Z') camRadius = constrain(camRadius - 80, 350, 2200);
+    else if (k == 'x' || k == 'X') camRadius = constrain(camRadius + 80, 350, 2200);
+    else super.handleKey(k);
+  }
+
+  // ── 3D trail (uses trail3D which has real Z values) ───────────────────────
+
+  void drawTrail(PGraphics pg) {
+    if (trail3D.size() < 2) return;
+    pg.pushStyle();
+    pg.colorMode(HSB, 360, 255, 255, 255);
+    pg.noFill();
+    pg.noLights();
+    for (int i = 1; i < trail3D.size(); i++) {
+      float a = map(i, 0, trail3D.size(), 0, 130);
+      float w = map(i, 0, trail3D.size(), 0.5, BALL_RADIUS * 0.65);
+      pg.stroke((int)ballHue, 180, 255, (int)a);
+      pg.strokeWeight(w);
+      PVector p = trail3D.get(i - 1);
+      PVector c = trail3D.get(i);
+      pg.line(p.x, p.y, p.z, c.x, c.y, c.z);
+    }
+    pg.lights();
+    pg.colorMode(RGB, 255);
+    pg.popStyle();
+  }
+}

--- a/Music_Visualizer_CK/TableTennisScene.pde
+++ b/Music_Visualizer_CK/TableTennisScene.pde
@@ -74,11 +74,16 @@ class TableTennisScene implements IScene {
   // ── physics ───────────────────────────────────────────────────────────────
   float gravity        = 0.28;
   float magnusStrength = 0.045;
+  float speedMult      = 1.3;    // global speed multiplier — adjustable in-game
   final float DRAG     = 0.999;
 
   // ── visuals ───────────────────────────────────────────────────────────────
   float ballHue     = 40;
   float impactFlash = 0;
+  float beatGlow    = 0;   // 1.0 on beat, decays — drives paddle aura
+  float bassSmooth  = 0;   // smoothed bass level — drives paddle height breathing
+  boolean powerReady = false; // true while beatGlow is hot enough for a power shot
+  float powerFlash  = 0;   // extra burst when power shot lands
   ArrayList<PVector> trail = new ArrayList<PVector>();
   final int MAX_TRAIL = 45;
 
@@ -144,6 +149,10 @@ class TableTennisScene implements IScene {
     if (analyzer.isBeat) onBeat(bass, mid);
     impactFlash *= 0.82;
     pointFlash  *= 0.88;
+    beatGlow    *= 0.93;
+    powerFlash  *= 0.85;
+    bassSmooth   = lerp(bassSmooth, bass, 0.15);
+    powerReady   = beatGlow > 0.4;
 
     drawTable(pg);
     updatePaddleTargets();
@@ -166,13 +175,14 @@ class TableTennisScene implements IScene {
     else            rightLungeX = lunge;
     spin += map(mid, 0, 15, -0.03, 0.03);
     spin  = constrain(spin, -0.25, 0.25);
+    beatGlow = 1.0;
   }
 
   // ── paddle AI ─────────────────────────────────────────────────────────────
 
   void updatePaddleTargets() {
     float yMin  = PADDLE_H / 2;
-    float yMax  = tableY - BALL_RADIUS;
+    float yMax  = tableY - PADDLE_H / 2 - 4;   // keep paddle above table surface
     float restY = tableY - 120;
 
     // During serve drop, and while the ball is heading to the server's own side
@@ -211,27 +221,17 @@ class TableTennisScene implements IScene {
       // Ball heading left — right paddle rests, left paddle tracks
       rightTargetX = rightHomeX;
       rightTargetY = constrain(restY, yMin, yMax);
-      if (lastBounceSide == -1) {
-        // Ball bounced on left — charge forward to intercept
-        leftTargetX = constrain(ballX + PADDLE_W, xMargin, netX - xMargin);
-      } else {
-        // Ball incoming, not yet bounced — hold home X but pre-track Y so paddle
-        // is already in position when the ball lands
-        leftTargetX = leftHomeX;
-      }
+      // Always retreat to behind home — ball is coming toward you, moving
+      // forward causes the ball to chip over the paddle edge
+      leftTargetX = leftHomeX - 20;
       float t = abs(ballX - leftPaddleX) / max(abs(ballVX), 0.5);
       leftTargetY = constrain(predictBallY(t) + leftMissOffset, yMin, yMax);
     } else {
       // Ball heading right — left paddle rests, right paddle tracks
       leftTargetX = leftHomeX;
       leftTargetY = constrain(restY, yMin, yMax);
-      if (lastBounceSide == 1) {
-        // Ball bounced on right — charge forward to intercept
-        rightTargetX = constrain(ballX - PADDLE_W, netX + xMargin, width - xMargin);
-      } else {
-        // Ball incoming, not yet bounced — hold home X but pre-track Y
-        rightTargetX = rightHomeX;
-      }
+      // Always retreat to behind home — ball is coming toward you
+      rightTargetX = rightHomeX + 20;
       float t = abs(rightPaddleX - ballX) / max(abs(ballVX), 0.5);
       rightTargetY = constrain(predictBallY(t) + rightMissOffset, yMin, yMax);
     }
@@ -278,7 +278,7 @@ class TableTennisScene implements IScene {
       float serveHitY = leftServes ? leftPaddleY : rightPaddleY;
       if (ballY >= serveHitY && ballVY > 0) {
         // Auto-hit: launch the serve downward into server's table half
-        float speed = 9 + rallyCount * 0.1;
+        float speed = (9 + rallyCount * 0.1) * speedMult;
         ballVX = leftServes ? speed : -speed;
         ballVY = 8;   // hits down so ball bounces on server's half first
         inServeDrop = false;
@@ -333,8 +333,9 @@ class TableTennisScene implements IScene {
     }
 
     // Speed floor — ball must keep moving after serve bounce
-    if (serveBounced && abs(ballVX) < MIN_SPEED_X) {
-      ballVX = (ballVX >= 0 ? 1 : -1) * MIN_SPEED_X;
+    float speedFloor = MIN_SPEED_X * speedMult;
+    if (serveBounced && abs(ballVX) < speedFloor) {
+      ballVX = (ballVX >= 0 ? 1 : -1) * speedFloor;
     }
 
     // Paddle collisions (receiver can't return during serve drop or serve bounce)
@@ -435,18 +436,21 @@ class TableTennisScene implements IScene {
     }
 
     float hitPos = constrain((ballY - paddleY) / (PADDLE_H / 2), -1, 1);
-    // Random power each shot — no escalation, keeps speed varied throughout the rally
-    float power    = random(6, 13);
-    float speedMod = random(0.88, 1.14);
-    float newSpeed = constrain(abs(ballVX) * speedMod + power * 0.3, 6, 22);
+
+    boolean isPowerShot = powerReady;
+    float power    = isPowerShot ? random(14, 20) : random(6, 13);
+    float speedMod = isPowerShot ? random(1.1, 1.35) : random(0.88, 1.14);
+    float cap      = (isPowerShot ? 30 : 22) * speedMult;
+    float newSpeed = constrain((abs(ballVX) * speedMod + power * 0.3) * speedMult, 6 * speedMult, cap);
     ballVX = isLeft ? newSpeed : -newSpeed;
-    // Random arc: sometimes a high lob, sometimes a flat drive
     ballVY = constrain(hitPos * 2 + random(-14, -1), -16, -2);
-    // Random spin regardless of hit position
-    spin   = random(-0.20, 0.20);
+    spin   = isPowerShot ? random(-0.35, 0.35) : random(-0.20, 0.20);
+
     rallyCount++;
-    impactFlash        = 1.0;
-    ballHue            = (ballHue + random(50, 100)) % 360;
+    impactFlash        = isPowerShot ? 1.5 : 1.0;
+    powerFlash         = isPowerShot ? 1.0 : 0;
+    beatGlow           = isPowerShot ? 0 : beatGlow;   // consume the charge
+    ballHue            = (ballHue + (isPowerShot ? random(120, 180) : random(50, 100))) % 360;
     lastHitSide        = isLeft ? -1 : 1;
     lastBounceSide     = 0;
     consecutiveBounces = 0;
@@ -615,25 +619,56 @@ class TableTennisScene implements IScene {
     float lx = leftPaddleX  + leftLungeX;
     float rx = rightPaddleX - rightLungeX;
 
+    // Bass breathing — visual height only, not hitbox
+    float breathe = bassSmooth * 18;
+    float lh = PADDLE_H + breathe;
+    float rh = PADDLE_H + breathe;
+
     pg.pushStyle();
       pg.rectMode(CENTER);
       pg.noStroke();
+      pg.colorMode(HSB, 360, 255, 255, 255);
 
-      if (impactFlash > 0.05) {
-        pg.fill(255, 255, 255, impactFlash * 120);
-        pg.rect(lx, leftPaddleY,  PADDLE_W + 10, PADDLE_H + 10, 4);
-        pg.rect(rx, rightPaddleY, PADDLE_W + 10, PADDLE_H + 10, 4);
+      // Beat-glow aura on the active (receiving) paddle
+      if (beatGlow > 0.05) {
+        boolean leftActive = ballVX < 0;
+        float ax = leftActive ? lx : rx;
+        float ay = leftActive ? leftPaddleY : rightPaddleY;
+        float ah = leftActive ? lh : rh;
+        float hue = powerReady ? 45 : 200;   // gold when power-ready, blue otherwise
+        for (int ring = 3; ring >= 1; ring--) {
+          float spread = ring * 12 * beatGlow;
+          pg.fill(hue, 220, 255, beatGlow * 60 / ring);
+          pg.rect(ax, ay, PADDLE_W + spread * 2, ah + spread * 2, 6);
+        }
       }
 
+      // Power-shot burst — wide radial flash at both paddles
+      if (powerFlash > 0.05) {
+        float spread = powerFlash * 60;
+        pg.fill(45, 255, 255, powerFlash * 90);
+        pg.ellipse(lx, leftPaddleY,  spread * 2, spread * 2);
+        pg.ellipse(rx, rightPaddleY, spread * 2, spread * 2);
+      }
+
+      // Impact flash (white) on both paddles
+      if (impactFlash > 0.05) {
+        pg.fill(0, 0, 255, impactFlash * 120);
+        pg.rect(lx, leftPaddleY,  PADDLE_W + 10, lh + 10, 4);
+        pg.rect(rx, rightPaddleY, PADDLE_W + 10, rh + 10, 4);
+      }
+
+      pg.colorMode(RGB, 255);
+
       pg.fill(200, 40, 40);
-      pg.rect(lx, leftPaddleY, PADDLE_W, PADDLE_H, 3);
+      pg.rect(lx, leftPaddleY, PADDLE_W, lh, 3);
       pg.fill(220, 70, 70, 140);
-      pg.rect(lx + 1, leftPaddleY, PADDLE_W * 0.4, PADDLE_H * 0.85, 2);
+      pg.rect(lx + 1, leftPaddleY, PADDLE_W * 0.4, lh * 0.85, 2);
 
       pg.fill(40, 40, 200);
-      pg.rect(rx, rightPaddleY, PADDLE_W, PADDLE_H, 3);
+      pg.rect(rx, rightPaddleY, PADDLE_W, rh, 3);
       pg.fill(70, 70, 220, 140);
-      pg.rect(rx - 1, rightPaddleY, PADDLE_W * 0.4, PADDLE_H * 0.85, 2);
+      pg.rect(rx - 1, rightPaddleY, PADDLE_W * 0.4, rh * 0.85, 2);
 
       // Serve indicator — small dot above the serving paddle
       pg.fill(255, 220, 0, 180);
@@ -713,12 +748,13 @@ class TableTennisScene implements IScene {
     pg.pushStyle();
       float ts = 11 * uiScale(), lh = ts * 1.3, mg = 4 * uiScale();
       pg.fill(0, 150); pg.noStroke(); pg.rectMode(CORNER);
-      pg.rect(8, 8, 240 * uiScale(), mg + lh * 4);
+      pg.rect(8, 8, 240 * uiScale(), mg + lh * 5);
       pg.fill(255); pg.textSize(ts); pg.textAlign(LEFT, TOP);
-      pg.text("Table Tennis",                             12, 8 + mg);
-      pg.text("Spin: " + sp + " (" + nf(spin,1,2) + ")", 12, 8 + mg + lh);
-      pg.text("Gravity: " + nf(gravity,1,2) + "  (+/-)",  12, 8 + mg + lh*2);
-      pg.text("Magnus: " + nf(magnusStrength,1,3) + "  ([/])", 12, 8 + mg + lh*3);
+      pg.text("Table Tennis",                                   12, 8 + mg);
+      pg.text("Spin: " + sp + " (" + nf(spin,1,2) + ")",       12, 8 + mg + lh);
+      pg.text("Gravity: " + nf(gravity,1,2) + "  (+/-)",        12, 8 + mg + lh*2);
+      pg.text("Magnus: " + nf(magnusStrength,1,3) + "  ([/])",  12, 8 + mg + lh*3);
+      pg.text("Speed: " + nf(speedMult,1,1) + "x  (,/.)",       12, 8 + mg + lh*4);
     pg.popStyle();
   }
 
@@ -732,6 +768,10 @@ class TableTennisScene implements IScene {
     magnusStrength = constrain(magnusStrength + delta, 0.0, 0.15);
   }
 
+  void adjustSpeed(float delta) {
+    speedMult = constrain(speedMult + delta, 0.5, 3.0);
+  }
+
   void applyController(Controller c) {
     // R Stick ↕ → gravity (incremental: push up = less, push down = more)
     float ry = map(c.ry, 0, height, -1, 1);
@@ -743,6 +783,10 @@ class TableTennisScene implements IScene {
 
     // A button → inject a serve-speed burst (ball speed floor up briefly)
     if (c.a_just_pressed) spin = constrain(spin + random(-0.15, 0.15), -0.25, 0.25);
+
+    // X / Y buttons → speed down / up
+    if (c.x_just_pressed) adjustSpeed(-0.1);
+    if (c.y_just_pressed) adjustSpeed( 0.1);
   }
 
   // ── code overlay ──────────────────────────────────────────────────────────
@@ -775,5 +819,7 @@ class TableTennisScene implements IScene {
     else if (k == '-') adjustGravity(-0.02);
     else if (k == '[') adjustMagnus(-0.005);
     else if (k == ']') adjustMagnus(0.005);
+    else if (k == ',') adjustSpeed(-0.1);
+    else if (k == '.') adjustSpeed(0.1);
   }
 }

--- a/scores.txt
+++ b/scores.txt
@@ -669,3 +669,557 @@ game  RIGHT wins  11-8  (games L:0 R:1)
 === session 2026-04-04 00:51:17 ===
 === session 2026-04-04 00:53:53 ===
 === session 2026-04-04 00:57:35 ===
+=== session 2026-04-05 20:05:08 ===
+  point  LEFT   [server  ]  rally:2  score 1-0
+  point  RIGHT  [receiver]  rally:2  score 1-1
+  point  RIGHT  [server  ]  rally:1  score 1-2
+  point  LEFT   [receiver]  rally:2  score 2-2
+  point  LEFT   [server  ]  rally:2  score 3-2
+=== session 2026-04-05 20:09:57 ===
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  RIGHT  [receiver]  rally:1  score 1-1
+  point  RIGHT  [server  ]  rally:1  score 1-2
+  point  RIGHT  [server  ]  rally:1  score 1-3
+  point  LEFT   [server  ]  rally:1  score 2-3
+  point  LEFT   [server  ]  rally:1  score 3-3
+  point  RIGHT  [server  ]  rally:1  score 3-4
+  point  LEFT   [receiver]  rally:2  score 4-4
+  point  LEFT   [server  ]  rally:0  score 5-4
+  point  LEFT   [server  ]  rally:0  score 6-4
+  point  RIGHT  [server  ]  rally:0  score 6-5
+  point  RIGHT  [server  ]  rally:0  score 6-6
+  point  LEFT   [server  ]  rally:0  score 7-6
+  point  LEFT   [server  ]  rally:0  score 8-6
+  point  RIGHT  [server  ]  rally:0  score 8-7
+  point  RIGHT  [server  ]  rally:0  score 8-8
+  point  LEFT   [server  ]  rally:0  score 9-8
+  point  LEFT   [server  ]  rally:0  score 10-8
+  point  RIGHT  [server  ]  rally:0  score 10-9
+  point  RIGHT  [server  ]  rally:0  score 10-10
+  point  LEFT   [server  ]  rally:0  score 11-10
+  point  RIGHT  [server  ]  rally:0  score 11-11
+  point  LEFT   [server  ]  rally:0  score 12-11
+  point  RIGHT  [server  ]  rally:0  score 12-12
+  point  LEFT   [server  ]  rally:0  score 13-12
+  point  RIGHT  [server  ]  rally:0  score 13-13
+  point  LEFT   [server  ]  rally:0  score 14-13
+  point  RIGHT  [server  ]  rally:0  score 14-14
+  point  LEFT   [server  ]  rally:1  score 15-14
+  point  RIGHT  [server  ]  rally:1  score 15-15
+  point  LEFT   [server  ]  rally:0  score 16-15
+  point  RIGHT  [server  ]  rally:0  score 16-16
+  point  LEFT   [server  ]  rally:0  score 17-16
+  point  RIGHT  [server  ]  rally:0  score 17-17
+  point  LEFT   [server  ]  rally:0  score 18-17
+  point  RIGHT  [server  ]  rally:0  score 18-18
+  point  LEFT   [server  ]  rally:1  score 19-18
+  point  RIGHT  [server  ]  rally:0  score 19-19
+  point  RIGHT  [receiver]  rally:3  score 19-20
+  point  RIGHT  [server  ]  rally:0  score 19-21
+game  RIGHT wins  21-19  (games L:0 R:1)
+  server won 92.5% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  LEFT   [server  ]  rally:0  score 2-0
+  point  RIGHT  [server  ]  rally:0  score 2-1
+  point  RIGHT  [server  ]  rally:0  score 2-2
+  point  RIGHT  [receiver]  rally:1  score 2-3
+  point  LEFT   [server  ]  rally:1  score 3-3
+  point  RIGHT  [server  ]  rally:1  score 3-4
+  point  LEFT   [receiver]  rally:2  score 4-4
+  point  LEFT   [server  ]  rally:2  score 5-4
+  point  LEFT   [server  ]  rally:1  score 6-4
+  point  RIGHT  [server  ]  rally:0  score 6-5
+  point  RIGHT  [server  ]  rally:1  score 6-6
+  point  LEFT   [server  ]  rally:1  score 7-6
+  point  RIGHT  [receiver]  rally:2  score 7-7
+  point  RIGHT  [server  ]  rally:0  score 7-8
+  point  RIGHT  [server  ]  rally:0  score 7-9
+  point  LEFT   [server  ]  rally:1  score 8-9
+  point  LEFT   [server  ]  rally:1  score 9-9
+  point  RIGHT  [server  ]  rally:0  score 9-10
+  point  RIGHT  [server  ]  rally:1  score 9-11
+game  RIGHT wins  11-9  (games L:0 R:2)
+  server won 85.0% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+=== session 2026-04-05 20:14:14 ===
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  LEFT   [server  ]  rally:2  score 1-0
+  point  LEFT   [server  ]  rally:1  score 1-1
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  LEFT   [receiver]  rally:1  score 3-0
+  point  LEFT   [receiver]  rally:3  score 2-1
+=== session 2026-04-05 20:22:25 ===
+=== session 2026-04-05 20:22:25 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+=== session 2026-04-05 20:22:46 ===
+=== session 2026-04-05 20:22:46 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:4  score 2-1
+  point  RIGHT  [server  ]  rally:1  score 2-2
+=== session 2026-04-05 20:27:10 ===
+=== session 2026-04-05 20:27:10 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:2  score 2-0
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:0  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  LEFT   [server  ]  rally:0  score 4-2
+  point  RIGHT  [server  ]  rally:1  score 4-3
+  point  LEFT   [receiver]  rally:1  score 5-3
+  point  LEFT   [server  ]  rally:1  score 6-3
+  point  LEFT   [server  ]  rally:1  score 7-3
+  point  RIGHT  [server  ]  rally:1  score 7-4
+  point  RIGHT  [server  ]  rally:1  score 7-5
+  point  LEFT   [server  ]  rally:1  score 8-5
+  point  LEFT   [server  ]  rally:1  score 9-5
+  point  RIGHT  [server  ]  rally:0  score 9-6
+  point  RIGHT  [server  ]  rally:3  score 9-7
+  point  RIGHT  [receiver]  rally:1  score 9-8
+  point  LEFT   [server  ]  rally:0  score 10-8
+  point  RIGHT  [server  ]  rally:1  score 10-9
+  point  LEFT   [receiver]  rally:3  score 11-9
+game  LEFT  wins  11-9  (games L:1 R:0)
+  server won 85.0% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  RIGHT  [receiver]  rally:1  score 1-1
+  point  RIGHT  [server  ]  rally:0  score 1-2
+  point  LEFT   [receiver]  rally:2  score 2-2
+  point  RIGHT  [receiver]  rally:1  score 2-3
+  point  LEFT   [server  ]  rally:0  score 3-3
+  point  RIGHT  [server  ]  rally:1  score 3-4
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:0  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  RIGHT  [receiver]  rally:1  score 3-3
+  point  RIGHT  [server  ]  rally:2  score 3-4
+  point  LEFT   [receiver]  rally:3  score 4-4
+  point  LEFT   [server  ]  rally:1  score 5-4
+=== session 2026-04-05 20:33:08 ===
+=== session 2026-04-05 20:33:09 ===
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  LEFT   [server  ]  rally:0  score 2-0
+  point  RIGHT  [server  ]  rally:0  score 2-1
+  point  RIGHT  [server  ]  rally:0  score 2-2
+  point  LEFT   [server  ]  rally:0  score 3-2
+  point  LEFT   [server  ]  rally:1  score 4-2
+  point  LEFT   [receiver]  rally:3  score 5-2
+  point  LEFT   [receiver]  rally:1  score 6-2
+  point  LEFT   [server  ]  rally:0  score 7-2
+  point  LEFT   [server  ]  rally:0  score 8-2
+  point  RIGHT  [server  ]  rally:0  score 8-3
+  point  RIGHT  [server  ]  rally:1  score 8-4
+  point  LEFT   [server  ]  rally:0  score 9-4
+  point  LEFT   [server  ]  rally:1  score 10-4
+  point  RIGHT  [server  ]  rally:1  score 10-5
+  point  RIGHT  [server  ]  rally:1  score 10-6
+  point  LEFT   [server  ]  rally:1  score 11-6
+game  LEFT  wins  11-6  (games L:1 R:0)
+  server won 88.2% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  RIGHT  [receiver]  rally:3  score 1-1
+  point  RIGHT  [server  ]  rally:1  score 1-2
+  point  RIGHT  [server  ]  rally:1  score 1-3
+  point  RIGHT  [receiver]  rally:1  score 1-4
+  point  LEFT   [server  ]  rally:2  score 2-4
+  point  LEFT   [receiver]  rally:1  score 3-4
+  point  LEFT   [receiver]  rally:2  score 4-4
+  point  LEFT   [server  ]  rally:1  score 5-4
+  point  LEFT   [server  ]  rally:1  score 6-4
+  point  RIGHT  [server  ]  rally:1  score 6-5
+  point  RIGHT  [server  ]  rally:1  score 6-6
+  point  LEFT   [server  ]  rally:2  score 7-6
+  point  RIGHT  [receiver]  rally:2  score 7-7
+  point  RIGHT  [server  ]  rally:1  score 7-8
+  point  LEFT   [receiver]  rally:1  score 8-8
+  point  LEFT   [server  ]  rally:1  score 9-8
+  point  RIGHT  [receiver]  rally:1  score 9-9
+  point  LEFT   [receiver]  rally:1  score 10-9
+  point  RIGHT  [server  ]  rally:0  score 10-10
+  point  LEFT   [server  ]  rally:2  score 11-10
+  point  RIGHT  [server  ]  rally:1  score 11-11
+  point  RIGHT  [receiver]  rally:1  score 11-12
+  point  LEFT   [receiver]  rally:2  score 12-12
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:1  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  LEFT   [server  ]  rally:2  score 4-2
+  point  RIGHT  [server  ]  rally:2  score 4-3
+  point  LEFT   [receiver]  rally:3  score 5-3
+  point  LEFT   [server  ]  rally:2  score 6-3
+  point  RIGHT  [receiver]  rally:1  score 6-4
+  point  RIGHT  [server  ]  rally:1  score 6-5
+  point  LEFT   [receiver]  rally:1  score 7-5
+  point  LEFT   [server  ]  rally:1  score 8-5
+  point  RIGHT  [receiver]  rally:2  score 8-6
+  point  LEFT   [receiver]  rally:2  score 9-6
+  point  LEFT   [receiver]  rally:1  score 10-6
+  point  LEFT   [server  ]  rally:3  score 11-6
+game  LEFT  wins  11-6  (games L:1 R:0)
+  server won 64.7% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:0  score 2-1
+  point  RIGHT  [server  ]  rally:4  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  LEFT   [server  ]  rally:2  score 4-2
+  point  RIGHT  [server  ]  rally:1  score 4-3
+  point  RIGHT  [server  ]  rally:3  score 4-4
+=== session 2026-04-05 20:43:56 ===
+=== session 2026-04-05 20:43:57 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:1  score 2-2
+  point  LEFT   [server  ]  rally:0  score 3-2
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:3  score 2-1
+  point  RIGHT  [server  ]  rally:1  score 2-2
+  point  RIGHT  [receiver]  rally:1  score 2-3
+  point  RIGHT  [receiver]  rally:1  score 2-4
+  point  RIGHT  [server  ]  rally:1  score 2-5
+  point  RIGHT  [server  ]  rally:1  score 2-6
+  point  LEFT   [server  ]  rally:1  score 3-6
+  point  RIGHT  [receiver]  rally:2  score 3-7
+  point  RIGHT  [server  ]  rally:0  score 3-8
+  point  LEFT   [receiver]  rally:1  score 4-8
+  point  LEFT   [server  ]  rally:4  score 5-8
+  point  LEFT   [server  ]  rally:0  score 6-8
+  point  RIGHT  [server  ]  rally:1  score 6-9
+  point  LEFT   [receiver]  rally:2  score 7-9
+  point  LEFT   [server  ]  rally:0  score 8-9
+  point  LEFT   [server  ]  rally:1  score 9-9
+  point  RIGHT  [server  ]  rally:1  score 9-10
+  point  RIGHT  [server  ]  rally:1  score 9-11
+game  RIGHT wins  11-9  (games L:0 R:1)
+  server won 75.0% of points  |  rallies 5+: 0.0%  |  longest: 4 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+=== session 2026-04-05 20:46:27 ===
+=== session 2026-04-05 20:46:27 ===
+=== session 2026-04-05 20:49:46 ===
+=== session 2026-04-05 20:49:46 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  LEFT   [server  ]  rally:1  score 1-1
+  point  LEFT   [receiver]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:0  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  LEFT   [server  ]  rally:1  score 4-2
+  point  LEFT   [receiver]  rally:1  score 5-2
+  point  RIGHT  [server  ]  rally:1  score 5-3
+  point  LEFT   [server  ]  rally:2  score 6-3
+  point  RIGHT  [receiver]  rally:2  score 6-4
+  point  RIGHT  [server  ]  rally:1  score 6-5
+  point  RIGHT  [server  ]  rally:1  score 6-6
+  point  RIGHT  [receiver]  rally:1  score 6-7
+  point  RIGHT  [receiver]  rally:1  score 6-8
+  point  LEFT   [receiver]  rally:1  score 7-8
+  point  RIGHT  [server  ]  rally:2  score 7-9
+  point  LEFT   [server  ]  rally:1  score 8-9
+  point  LEFT   [server  ]  rally:2  score 9-9
+  point  LEFT   [receiver]  rally:1  score 10-9
+  point  LEFT   [receiver]  rally:1  score 11-9
+game  LEFT  wins  11-9  (games L:1 R:0)
+  server won 55.0% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+  point  RIGHT  [receiver]  rally:2  score 0-1
+  point  LEFT   [server  ]  rally:0  score 1-1
+  point  RIGHT  [server  ]  rally:1  score 1-2
+  point  RIGHT  [server  ]  rally:1  score 1-3
+  point  LEFT   [server  ]  rally:1  score 2-3
+  point  RIGHT  [receiver]  rally:1  score 2-4
+  point  RIGHT  [server  ]  rally:0  score 2-5
+  point  RIGHT  [server  ]  rally:2  score 2-6
+  point  LEFT   [server  ]  rally:1  score 3-6
+  point  RIGHT  [receiver]  rally:1  score 3-7
+  point  LEFT   [receiver]  rally:1  score 4-7
+  point  LEFT   [receiver]  rally:1  score 5-7
+  point  LEFT   [server  ]  rally:1  score 6-7
+  point  LEFT   [server  ]  rally:0  score 7-7
+  point  LEFT   [receiver]  rally:1  score 8-7
+  point  LEFT   [receiver]  rally:1  score 9-7
+  point  RIGHT  [receiver]  rally:1  score 9-8
+  point  LEFT   [server  ]  rally:0  score 10-8
+  point  LEFT   [receiver]  rally:1  score 11-8
+game  LEFT  wins  11-8  (games L:2 R:0)
+  server won 52.6% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  LEFT   [server  ]  rally:1  score 1-1
+  point  LEFT   [receiver]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:2  score 2-2
+  point  LEFT   [server  ]  rally:2  score 3-2
+  point  LEFT   [server  ]  rally:0  score 4-2
+  point  RIGHT  [server  ]  rally:0  score 4-3
+  point  RIGHT  [server  ]  rally:1  score 4-4
+  point  LEFT   [server  ]  rally:1  score 5-4
+  point  RIGHT  [receiver]  rally:1  score 5-5
+  point  RIGHT  [server  ]  rally:3  score 5-6
+  point  RIGHT  [server  ]  rally:2  score 5-7
+  point  RIGHT  [receiver]  rally:1  score 5-8
+  point  LEFT   [server  ]  rally:0  score 6-8
+  point  RIGHT  [server  ]  rally:2  score 6-9
+  point  RIGHT  [server  ]  rally:2  score 6-10
+  point  LEFT   [server  ]  rally:3  score 7-10
+  point  LEFT   [server  ]  rally:1  score 8-10
+  point  RIGHT  [server  ]  rally:1  score 8-11
+game  RIGHT wins  11-8  (games L:2 R:1)
+  server won 78.9% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  RIGHT  [receiver]  rally:1  score 0-2
+  point  LEFT   [receiver]  rally:1  score 1-2
+  point  RIGHT  [server  ]  rally:0  score 1-3
+  point  LEFT   [server  ]  rally:1  score 2-3
+  point  RIGHT  [receiver]  rally:2  score 2-4
+  point  LEFT   [receiver]  rally:2  score 3-4
+  point  LEFT   [receiver]  rally:1  score 4-4
+  point  RIGHT  [receiver]  rally:3  score 4-5
+  point  LEFT   [server  ]  rally:0  score 5-5
+  point  LEFT   [receiver]  rally:1  score 6-5
+=== session 2026-04-05 20:54:40 ===
+=== session 2026-04-05 20:54:40 ===
+=== session 2026-04-05 20:55:08 ===
+=== session 2026-04-05 20:55:08 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+=== session 2026-04-05 20:55:17 ===
+=== session 2026-04-05 20:55:17 ===
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  RIGHT  [server  ]  rally:2  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  RIGHT  [receiver]  rally:1  score 3-3
+  point  LEFT   [receiver]  rally:3  score 4-3
+  point  RIGHT  [server  ]  rally:2  score 4-4
+  point  RIGHT  [receiver]  rally:1  score 4-5
+  point  LEFT   [server  ]  rally:1  score 5-5
+  point  RIGHT  [server  ]  rally:1  score 5-6
+  point  RIGHT  [server  ]  rally:1  score 5-7
+  point  RIGHT  [receiver]  rally:1  score 5-8
+  point  LEFT   [server  ]  rally:1  score 6-8
+  point  LEFT   [receiver]  rally:1  score 7-8
+  point  RIGHT  [server  ]  rally:2  score 7-9
+  point  RIGHT  [receiver]  rally:1  score 7-10
+  point  RIGHT  [receiver]  rally:3  score 7-11
+game  RIGHT wins  11-7  (games L:0 R:1)
+  server won 61.1% of points  |  rallies 5+: 0.0%  |  longest: 3 hits
+---
+  point  LEFT   [server  ]  rally:2  score 1-0
+  point  LEFT   [server  ]  rally:3  score 2-0
+  point  RIGHT  [server  ]  rally:2  score 2-1
+  point  LEFT   [receiver]  rally:3  score 3-1
+  point  LEFT   [server  ]  rally:6 ***  score 4-1
+  point  LEFT   [server  ]  rally:1  score 5-1
+  point  RIGHT  [server  ]  rally:2  score 5-2
+  point  RIGHT  [server  ]  rally:3  score 5-3
+  point  LEFT   [server  ]  rally:1  score 6-3
+  point  RIGHT  [receiver]  rally:2  score 6-4
+  point  RIGHT  [server  ]  rally:1  score 6-5
+  point  LEFT   [receiver]  rally:3  score 7-5
+  point  RIGHT  [receiver]  rally:3  score 7-6
+  point  LEFT   [server  ]  rally:1  score 8-6
+  point  LEFT   [receiver]  rally:1  score 9-6
+  point  RIGHT  [server  ]  rally:1  score 9-7
+  point  LEFT   [server  ]  rally:1  score 10-7
+  point  RIGHT  [receiver]  rally:1  score 10-8
+  point  LEFT   [receiver]  rally:13 ***  score 11-8
+game  LEFT  wins  11-8  (games L:1 R:1)
+  server won 63.2% of points  |  rallies 5+: 10.5%  |  longest: 13 hits
+---
+  point  LEFT   [server  ]  rally:0  score 1-0
+  point  RIGHT  [receiver]  rally:1  score 1-1
+  point  LEFT   [receiver]  rally:9 ***  score 2-1
+  point  LEFT   [receiver]  rally:1  score 3-1
+  point  LEFT   [server  ]  rally:1  score 4-1
+  point  RIGHT  [receiver]  rally:1  score 4-2
+  point  LEFT   [receiver]  rally:1  score 5-2
+  point  LEFT   [receiver]  rally:1  score 6-2
+  point  RIGHT  [receiver]  rally:1  score 6-3
+  point  LEFT   [server  ]  rally:1  score 7-3
+=== session 2026-04-05 20:59:00 ===
+=== session 2026-04-05 20:59:01 ===
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  RIGHT  [server  ]  rally:1  score 2-1
+  point  LEFT   [receiver]  rally:1  score 3-1
+  point  LEFT   [server  ]  rally:1  score 4-1
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  LEFT   [server  ]  rally:2  score 1-1
+  point  LEFT   [receiver]  rally:1  score 2-1
+  point  RIGHT  [server  ]  rally:1  score 2-2
+  point  LEFT   [server  ]  rally:1  score 3-2
+  point  RIGHT  [receiver]  rally:1  score 3-3
+  point  RIGHT  [server  ]  rally:1  score 3-4
+=== session 2026-04-05 21:02:43 ===
+=== session 2026-04-05 21:02:43 ===
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  RIGHT  [receiver]  rally:1  score 0-2
+  point  LEFT   [receiver]  rally:1  score 1-2
+  point  LEFT   [receiver]  rally:1  score 2-2
+  point  RIGHT  [receiver]  rally:1  score 2-3
+  point  LEFT   [server  ]  rally:1  score 3-3
+  point  LEFT   [receiver]  rally:2  score 4-3
+  point  LEFT   [receiver]  rally:1  score 5-3
+  point  RIGHT  [receiver]  rally:1  score 5-4
+  point  LEFT   [server  ]  rally:2  score 6-4
+  point  LEFT   [receiver]  rally:1  score 7-4
+  point  LEFT   [receiver]  rally:1  score 8-4
+  point  RIGHT  [receiver]  rally:1  score 8-5
+  point  LEFT   [server  ]  rally:2  score 9-5
+  point  LEFT   [receiver]  rally:1  score 10-5
+  point  RIGHT  [server  ]  rally:1  score 10-6
+  point  RIGHT  [receiver]  rally:1  score 10-7
+  point  LEFT   [server  ]  rally:1  score 11-7
+game  LEFT  wins  11-7  (games L:1 R:0)
+  server won 27.8% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+  point  LEFT   [server  ]  rally:2  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  LEFT   [receiver]  rally:1  score 3-0
+  point  RIGHT  [server  ]  rally:2  score 3-1
+  point  LEFT   [server  ]  rally:1  score 4-1
+  point  RIGHT  [receiver]  rally:2  score 4-2
+  point  RIGHT  [server  ]  rally:1  score 4-3
+  point  RIGHT  [server  ]  rally:1  score 4-4
+  point  LEFT   [server  ]  rally:1  score 5-4
+  point  LEFT   [server  ]  rally:1  score 6-4
+  point  LEFT   [receiver]  rally:3  score 7-4
+  point  RIGHT  [server  ]  rally:1  score 7-5
+  point  LEFT   [server  ]  rally:1  score 8-5
+  point  RIGHT  [receiver]  rally:1  score 8-6
+  point  RIGHT  [server  ]  rally:2  score 8-7
+  point  RIGHT  [server  ]  rally:1  score 8-8
+  point  RIGHT  [receiver]  rally:2  score 8-9
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:1  score 2-0
+  point  LEFT   [receiver]  rally:1  score 3-0
+  point  RIGHT  [server  ]  rally:1  score 3-1
+  point  RIGHT  [receiver]  rally:1  score 3-2
+  point  LEFT   [server  ]  rally:1  score 4-2
+  point  RIGHT  [server  ]  rally:2  score 4-3
+  point  LEFT   [receiver]  rally:2  score 5-3
+  point  RIGHT  [receiver]  rally:1  score 5-4
+  point  LEFT   [server  ]  rally:1  score 6-4
+  point  LEFT   [receiver]  rally:1  score 7-4
+  point  RIGHT  [server  ]  rally:1  score 7-5
+  point  LEFT   [server  ]  rally:2  score 8-5
+  point  RIGHT  [receiver]  rally:2  score 8-6
+  point  LEFT   [receiver]  rally:1  score 9-6
+  point  LEFT   [receiver]  rally:2  score 10-6
+  point  LEFT   [server  ]  rally:1  score 11-6
+game  LEFT  wins  11-6  (games L:1 R:0)
+  server won 52.9% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  LEFT   [server  ]  rally:1  score 1-1
+  point  RIGHT  [server  ]  rally:2  score 1-2
+  point  RIGHT  [server  ]  rally:1  score 1-3
+  point  LEFT   [server  ]  rally:1  score 2-3
+  point  RIGHT  [receiver]  rally:1  score 2-4
+  point  LEFT   [receiver]  rally:3  score 3-4
+  point  LEFT   [receiver]  rally:1  score 4-4
+  point  LEFT   [server  ]  rally:1  score 5-4
+  point  RIGHT  [receiver]  rally:1  score 5-5
+  point  LEFT   [receiver]  rally:1  score 6-5
+  point  LEFT   [receiver]  rally:1  score 7-5
+  point  RIGHT  [receiver]  rally:2  score 7-6
+  point  RIGHT  [receiver]  rally:1  score 7-7
+  point  RIGHT  [server  ]  rally:0  score 7-8
+  point  LEFT   [receiver]  rally:2  score 8-8
+  point  LEFT   [server  ]  rally:1  score 9-8
+  point  RIGHT  [receiver]  rally:2  score 9-9
+  point  LEFT   [receiver]  rally:2  score 10-9
+  point  RIGHT  [server  ]  rally:1  score 10-10
+  point  RIGHT  [receiver]  rally:17 ***  score 10-11
+  point  RIGHT  [server  ]  rally:16 ***  score 10-12
+game  RIGHT wins  12-10  (games L:1 R:1)
+  server won 40.9% of points  |  rallies 5+: 9.1%  |  longest: 17 hits
+---
+  point  RIGHT  [receiver]  rally:11 ***  score 0-1
+  point  LEFT   [server  ]  rally:1  score 1-1
+  point  LEFT   [receiver]  rally:1  score 2-1
+  point  LEFT   [receiver]  rally:1  score 3-1
+  point  RIGHT  [receiver]  rally:1  score 3-2
+  point  RIGHT  [receiver]  rally:1  score 3-3
+  point  LEFT   [receiver]  rally:5 ***  score 4-3
+  point  LEFT   [receiver]  rally:1  score 5-3
+  point  RIGHT  [receiver]  rally:1  score 5-4
+  point  RIGHT  [receiver]  rally:1  score 5-5
+  point  RIGHT  [server  ]  rally:0  score 5-6
+  point  RIGHT  [server  ]  rally:1  score 5-7
+  point  LEFT   [server  ]  rally:2  score 6-7
+  point  LEFT   [server  ]  rally:1  score 7-7
+  point  RIGHT  [server  ]  rally:1  score 7-8
+  point  LEFT   [receiver]  rally:1  score 8-8
+  point  RIGHT  [receiver]  rally:13 ***  score 8-9
+  point  RIGHT  [receiver]  rally:1  score 8-10
+  point  LEFT   [receiver]  rally:1  score 9-10
+  point  LEFT   [receiver]  rally:1  score 10-10
+  point  LEFT   [server  ]  rally:2  score 11-10
+  point  LEFT   [receiver]  rally:1  score 12-10
+game  LEFT  wins  12-10  (games L:2 R:1)
+  server won 31.8% of points  |  rallies 5+: 13.6%  |  longest: 13 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  LEFT   [server  ]  rally:2  score 2-0
+  point  LEFT   [receiver]  rally:2  score 3-0
+  point  RIGHT  [server  ]  rally:4  score 3-1
+  point  LEFT   [server  ]  rally:2  score 4-1
+  point  RIGHT  [receiver]  rally:1  score 4-2
+  point  RIGHT  [server  ]  rally:1  score 4-3
+  point  LEFT   [receiver]  rally:1  score 5-3
+  point  LEFT   [server  ]  rally:1  score 6-3
+  point  LEFT   [server  ]  rally:1  score 7-3
+  point  RIGHT  [server  ]  rally:2  score 7-4
+  point  LEFT   [receiver]  rally:2  score 8-4
+  point  LEFT   [server  ]  rally:1  score 9-4
+  point  LEFT   [server  ]  rally:2  score 10-4
+  point  LEFT   [receiver]  rally:1  score 11-4
+game  LEFT  wins  11-4  (games L:3 R:1)
+  server won 66.7% of points  |  rallies 5+: 0.0%  |  longest: 4 hits
+---
+  point  RIGHT  [receiver]  rally:1  score 0-1
+  point  RIGHT  [receiver]  rally:1  score 0-2
+  point  RIGHT  [server  ]  rally:1  score 0-3
+  point  RIGHT  [server  ]  rally:1  score 0-4
+  point  RIGHT  [receiver]  rally:1  score 0-5
+  point  RIGHT  [receiver]  rally:1  score 0-6
+  point  LEFT   [receiver]  rally:1  score 1-6
+  point  RIGHT  [server  ]  rally:2  score 1-7
+  point  LEFT   [server  ]  rally:2  score 2-7
+  point  LEFT   [server  ]  rally:1  score 3-7
+  point  LEFT   [receiver]  rally:1  score 4-7
+  point  RIGHT  [server  ]  rally:1  score 4-8
+  point  RIGHT  [receiver]  rally:1  score 4-9
+  point  RIGHT  [receiver]  rally:2  score 4-10
+  point  RIGHT  [server  ]  rally:2  score 4-11
+game  RIGHT wins  11-4  (games L:3 R:2)
+  server won 46.7% of points  |  rallies 5+: 0.0%  |  longest: 2 hits
+---
+  point  LEFT   [server  ]  rally:1  score 1-0
+  point  RIGHT  [receiver]  rally:2  score 1-1
+  point  RIGHT  [server  ]  rally:1  score 1-2
+  point  RIGHT  [server  ]  rally:1  score 1-3
+  point  LEFT   [server  ]  rally:1  score 2-3
+  point  RIGHT  [receiver]  rally:1  score 2-4
+  point  LEFT   [receiver]  rally:3  score 3-4
+  point  LEFT   [receiver]  rally:2  score 4-4
+  point  RIGHT  [receiver]  rally:2  score 4-5
+  point  RIGHT  [receiver]  rally:1  score 4-6
+  point  RIGHT  [server  ]  rally:2  score 4-7
+  point  RIGHT  [server  ]  rally:1  score 4-8
+  point  LEFT   [server  ]  rally:1  score 5-8


### PR DESCRIPTION
## Summary

- **Scene 25 — TableTennis3DScene**: orbit camera, Z-axis ball physics, 3D racket rendering. Extends TableTennisScene so all physics/rules/AI are inherited.
- **TableTennisScene**: beat-reactive power shots, bass-breathing paddle height, beat-glow aura, speed multiplier (`,`/`.` / X/Y buttons), fixed AI retreat bug, fixed paddle clipping into table.
- **Main file**: `fileSelected()` return type fix, `O` key opens song picker at runtime, title bar shows scene + path.

## Test plan

- [ ] Navigate to scene 25 — confirm 3D orbit camera, Z-drift on ball, 3D racket shapes
- [ ] Switch to scene 6 (2D) — verify no bleed, AI still works
- [ ] On beat: gold aura and power shot burst on both scenes
- [ ] `,`/`.` — speed multiplier changes and HUD updates
- [ ] `O` key — file picker loads a new song without restart