### PR TITLE
feat: TT3D psychedelic shaders, player control, physics fixes

### DIFF
--- a/Music_Visualizer_CK/TableTennis3DScene.pde
+++ b/Music_Visualizer_CK/TableTennis3DScene.pde
@@ -6,40 +6,99 @@
 // Adds Z-axis shot variation: each paddle hit gives the ball a random
 // lateral (Z) velocity. Ball bounces off the table's Z edges.
 // Racket shapes: oval face (flattened sphere) + wooden handle.
+//
+// Psychedelic post-process styles (F / D-pad L/R to cycle):
+//   0 = Normal  |  1 = Acid Warp  |  2 = Chromatic Glitch  |  3 = Neon Bloom
+//
+// Player control (V / B button to cycle):
+//   0 = AI both  |  1 = human plays left (red)  |  2 = human plays right (blue)
+//   Controller: left stick → paddle Y + Z   Keyboard: I/K = up/down, J/M = Z depth
 
 class TableTennis3DScene extends TableTennisScene {
 
   // ── orbit camera ──────────────────────────────────────────────────────────
-  float camAzim   =  0.15;    // horizontal angle around table (radians)
-  float camElev   =  0.42;    // vertical tilt (radians; 0=horizontal, PI/2=straight down)
-  float camRadius = 950;      // distance from orbit centre
+  float camAzim   =  0.15;
+  float camElev   =  0.42;
+  float camRadius = 950;
   float shake     =  0;
 
   // ── table dimensions ──────────────────────────────────────────────────────
-  final float TABLE_DEPTH = 680;   // Z extent of the table
-  final float PADDLE_D    = 18;    // racket face thickness (X axis, thin)
-  final float PADDLE_Z    = 130;   // racket face Z width (bat-sized)
+  final float TABLE_DEPTH = 680;
+  final float PADDLE_D    = 18;
+  final float PADDLE_Z    = 130;
 
-  // ── Z physics (supplementary — ball Z is 0 in parent) ────────────────────
+  // ── Z physics ─────────────────────────────────────────────────────────────
   float ballZ      = 0;
   float ballVZ     = 0;
   int   prevRallyCount = 0;
 
-  // ── paddle Z positions (3D only — parent only tracks X/Y) ────────────────
+  // ── paddle Z positions ────────────────────────────────────────────────────
   float leftPaddleZ  = 0;
   float rightPaddleZ = 0;
 
-  // ── 3D trail (includes Z) ─────────────────────────────────────────────────
+  // ── 3D trail ──────────────────────────────────────────────────────────────
   ArrayList<PVector> trail3D = new ArrayList<PVector>();
+
+  // ── shader / post-process ─────────────────────────────────────────────────
+  // 0=Normal  1=Acid Warp  2=Chromatic Glitch  3=Neon Bloom
+  int     shaderStyle = 0;
+  final String[] STYLE_NAMES = {"Normal", "Acid Warp", "Chromatic Glitch", "Neon Bloom"};
+  PShader acidShader, chromaticShader, neonShader;
+  PGraphics innerBuf;      // 3D scene renders here; post-process blits to pg
+  float   sceneTime = 0;   // seconds, accumulated
+
+  // ── player control ────────────────────────────────────────────────────────
+  // 0=AI both  1=human left (red)  2=human right (blue)
+  int   playerSide    = 0;
+  float playerTargetY = 0;
+  float playerTargetZ = 0;
+
+  // ── environment (expanded skybox) ─────────────────────────────────────────
+  // Generous space — table is ~1689 × 680 at 1920p, so 4× that gives breathing room
+  final float ENV_HW         = 2800;   // half-width  (X)  was 1400
+  final float ENV_HD         = 1400;   // half-depth  (Z)  was 600
+  final float ENV_TOP        = -900;   // ceiling Y        was -400
+  final float ENV_BOT_OFFSET =  320;   // floor offset below tableY
 
   TableTennis3DScene() {
     super();
   }
 
+  void onEnter() {
+    super.onEnter();
+    playerTargetY = tableY - 120;
+    playerTargetZ = 0;
+  }
+
+  // ── lazy shader/buffer init ───────────────────────────────────────────────
+
+  void ensureResources(PGraphics pg) {
+    if (innerBuf == null || innerBuf.width != pg.width || innerBuf.height != pg.height) {
+      innerBuf = createGraphics(pg.width, pg.height, P3D);
+    }
+    if (acidShader     == null) acidShader     = loadShader("tt3d_acid.glsl");
+    if (chromaticShader == null) chromaticShader = loadShader("tt3d_chromatic.glsl");
+    if (neonShader     == null) neonShader     = loadShader("tt3d_neon.glsl");
+  }
+
+  PShader activeShader() {
+    if (shaderStyle == 1) return acidShader;
+    if (shaderStyle == 2) return chromaticShader;
+    if (shaderStyle == 3) return neonShader;
+    return null;
+  }
+
+  void updateShaderUniforms(PShader sh, float bass) {
+    sh.set("u_bass",      constrain(bass * 2.5, 0, 1));
+    sh.set("u_intensity", 1.0);
+    if (shaderStyle == 1 || shaderStyle == 2) sh.set("u_time", sceneTime);
+  }
+
   // ── main draw ─────────────────────────────────────────────────────────────
 
   void drawScene(PGraphics pg) {
-    pg.background(10, 28, 10);
+    ensureResources(pg);
+    sceneTime += 1.0 / 60.0;
 
     float bass = 0, mid = 0;
     for (int i = 0;  i < 8;  i++) bass += analyzer.spectrum[i];
@@ -57,64 +116,74 @@ class TableTennis3DScene extends TableTennisScene {
     shake       *= 0.80;
     if (powerFlash > 0.7) shake = powerFlash * 7;
 
-    // Physics — inherited 2D physics + our Z layer
+    applyPlayerKeyboard();
     updatePaddleTargets();
     movePaddles();
+    updateZPhysics();   // Z first so paddle Z is fresh when collision fires
     updatePhysics();
-    updateZPhysics();
 
-    // Build the 3D trail (replaces parent's 2D trail in rendering)
     trail3D.add(new PVector(ballX, ballY, ballZ));
     if (trail3D.size() > MAX_TRAIL) trail3D.remove(0);
 
-    // Power-shot zoom: temporarily shrink radius
-    float radius = camRadius - powerFlash * 80;
+    // ── Render 3D scene to innerBuf ──────────────────────────────────────────
+    innerBuf.beginDraw();
+    innerBuf.background(10, 28, 10);
 
-    // Orbit centre — middle of the table/rally area
+    float radius = camRadius - powerFlash * 80;
     float cx = width / 2.0;
-    float cy = tableY - 60;    // slightly above the table surface
+    float cy = tableY - 60;
     float cz = 0;
 
-    // Spherical → Cartesian (Y-down P3D convention: elevation raises the eye = decreases Y)
     float shakeX = shake > 0.1 ? random(-shake, shake) : 0;
     float shakeY = shake > 0.1 ? random(-shake, shake) * 0.3 : 0;
     float eyeX = cx + radius * cos(camElev) * sin(camAzim) + shakeX;
     float eyeY = cy - radius * sin(camElev)                + shakeY;
     float eyeZ = cz + radius * cos(camElev) * cos(camAzim);
 
-    pg.camera(eyeX, eyeY, eyeZ, cx, cy, cz, 0, 1, 0);
-    pg.perspective(PI / 3.0, (float)pg.width / pg.height, 10, 8000);
+    innerBuf.camera(eyeX, eyeY, eyeZ, cx, cy, cz, 0, 1, 0);
+    innerBuf.perspective(PI / 3.0, (float)innerBuf.width / innerBuf.height, 10, 12000);
 
-    // Lighting
-    pg.ambientLight(25, 55, 25);
-    pg.directionalLight(160, 200, 160, 0.2, 1.0, -0.4);
+    innerBuf.ambientLight(25, 55, 25);
+    innerBuf.directionalLight(160, 200, 160, 0.2, 1.0, -0.4);
     float bl = 80 + beatGlow * 175;
-    pg.pointLight((int)(bl * 0.85), (int)bl, (int)(bl * 0.5), ballX, ballY, ballZ);
+    innerBuf.pointLight((int)(bl * 0.85), (int)bl, (int)(bl * 0.5), ballX, ballY, ballZ);
     if (powerFlash > 0.05)
-      pg.pointLight(255, 210, 60, ballX, ballY, ballZ);
+      innerBuf.pointLight(255, 210, 60, ballX, ballY, ballZ);
 
-    drawEnvironmentFloor(pg);
-    drawTable(pg);
-    drawTrail(pg);
-    drawPaddles(pg);
-    drawBall(pg);
-    drawEnvironmentWalls(pg);
+    drawEnvironmentFloor(innerBuf);
+    drawTable(innerBuf);
+    drawTrail(innerBuf);
+    drawPaddles(innerBuf);
+    drawBall(innerBuf);
+    drawEnvironmentWalls(innerBuf, bass, mid);
 
-    // Reset to screen-space for 2D HUD
+    innerBuf.endDraw();
+
+    // ── Post-process blit to pg ───────────────────────────────────────────────
     pg.camera();
     pg.perspective();
     pg.noLights();
     pg.hint(DISABLE_DEPTH_TEST);
+
+    PShader sh = activeShader();
+    if (sh != null) {
+      updateShaderUniforms(sh, bass);
+      pg.shader(sh);
+    }
+    pg.image(innerBuf, 0, 0);
+    if (sh != null) pg.resetShader();
+
+    // ── HUD draws directly on pg (no post-process) ───────────────────────────
     drawScore(pg);
     drawHUD(pg);
     drawSongNameOnScreen(pg, config.SONG_NAME, pg.width / 2.0, pg.height - 5);
+
     pg.hint(ENABLE_DEPTH_TEST);
   }
 
   // ── Z physics ─────────────────────────────────────────────────────────────
 
   void updateZPhysics() {
-    // During serve drop, drift everything smoothly back to centre
     if (inServeDrop) {
       ballZ        = lerp(ballZ, 0, 0.06);
       ballVZ      *= 0.88;
@@ -124,13 +193,10 @@ class TableTennis3DScene extends TableTennisScene {
       return;
     }
 
-    // Detect a new paddle hit (rallyCount just increased)
     if (rallyCount > prevRallyCount) {
-      // Power shots get stronger lateral angle
       float maxZ = powerReady ? 7.0 : 4.5;
       ballVZ = random(-maxZ, maxZ);
     }
-    // Point scored — rally restarted
     if (rallyCount == 0 && prevRallyCount > 0) {
       ballZ  = 0;
       ballVZ = 0;
@@ -141,7 +207,6 @@ class TableTennis3DScene extends TableTennisScene {
     ballVZ *= 0.994;
     ballZ  += ballVZ;
 
-    // Bounce off Z table edges
     float zEdge = TABLE_DEPTH / 2.0 - BALL_RADIUS * 2;
     if (ballZ > zEdge) {
       ballZ  =  zEdge;
@@ -151,34 +216,75 @@ class TableTennis3DScene extends TableTennisScene {
       ballVZ *= -0.65;
     }
 
-    // Paddle Z tracking — receiving paddle follows ball Z, other returns to centre
-    float zLerpSpeed = 0.06;
-    if (ballVX < 0) {
-      // Ball heading left — left paddle is the receiver
-      leftPaddleZ  = lerp(leftPaddleZ,  ballZ, zLerpSpeed);
-      rightPaddleZ = lerp(rightPaddleZ, 0,     zLerpSpeed * 0.5);
+    // Predict ball Z at intercept so AI doesn't chase current position but destination.
+    float zEdgePred = TABLE_DEPTH / 2.0 - BALL_RADIUS * 2;
+    float tLeft  = abs(ballX - leftPaddleX)  / max(abs(ballVX), 0.5);
+    float tRight = abs(rightPaddleX - ballX) / max(abs(ballVX), 0.5);
+    // Simple linear prediction with Z drag (0.994^t ≈ well-approximated as linear for typical t)
+    float predZL = constrain(ballZ + ballVZ * tLeft,  -zEdgePred, zEdgePred);
+    float predZR = constrain(ballZ + ballVZ * tRight, -zEdgePred, zEdgePred);
+    float zSpeed = 0.09;   // faster tracking now that prediction is accurate
+
+    if (playerSide == 1) {
+      leftPaddleZ  = lerp(leftPaddleZ, playerTargetZ, 0.18);
+      rightPaddleZ = lerp(rightPaddleZ, ballVX > 0 ? predZR : 0, zSpeed);
+    } else if (playerSide == 2) {
+      rightPaddleZ = lerp(rightPaddleZ, playerTargetZ, 0.18);
+      leftPaddleZ  = lerp(leftPaddleZ, ballVX < 0 ? predZL : 0, zSpeed);
     } else {
-      // Ball heading right — right paddle is the receiver
-      rightPaddleZ = lerp(rightPaddleZ, ballZ, zLerpSpeed);
-      leftPaddleZ  = lerp(leftPaddleZ,  0,     zLerpSpeed * 0.5);
+      if (ballVX < 0) {
+        leftPaddleZ  = lerp(leftPaddleZ,  predZL, zSpeed);
+        rightPaddleZ = lerp(rightPaddleZ, 0,      zSpeed * 0.5);
+      } else {
+        rightPaddleZ = lerp(rightPaddleZ, predZR, zSpeed);
+        leftPaddleZ  = lerp(leftPaddleZ,  0,      zSpeed * 0.5);
+      }
     }
   }
 
-  // Override collision to add Z gating — parent only checks X/Y.
-  // Ball must be within the paddle's Z half-extent to register a hit.
   void checkPaddleCollision(boolean isLeft, float paddleX, float paddleY) {
     float pz = isLeft ? leftPaddleZ : rightPaddleZ;
     if (abs(ballZ - pz) > PADDLE_Z / 2.0 + BALL_RADIUS) return;
     super.checkPaddleCollision(isLeft, paddleX, paddleY);
   }
 
-  // ── environment (ground + enclosure box) ─────────────────────────────────
+  // ── player control helpers ────────────────────────────────────────────────
 
-  // Shared box dimensions
-  final float ENV_HW  = 1400;   // half-width  (X)
-  final float ENV_HD  = 600;    // half-depth  (Z)
-  final float ENV_TOP = -400;   // ceiling Y
-  final float ENV_BOT_OFFSET = 260; // how far below tableY the floor sits
+  // Override AI target-setting so the human side uses playerTargetY instead.
+  void updatePaddleTargets() {
+    super.updatePaddleTargets();
+    if (playerSide == 0) return;
+    float yMin = PADDLE_H / 2;
+    float yMax = tableY - PADDLE_H / 2 - 4;
+    playerTargetY = constrain(playerTargetY, yMin, yMax);
+    if (playerSide == 1) {
+      leftTargetY = playerTargetY;
+      leftTargetX = leftHomeX;
+    } else {
+      rightTargetY = playerTargetY;
+      rightTargetX = rightHomeX;
+    }
+  }
+
+  // Poll held keyboard keys each frame for smooth paddle movement.
+  void applyPlayerKeyboard() {
+    if (playerSide == 0 || !keyPressed) return;
+    float ySpeed = 6.0;
+    float zSpeed = 5.0;
+    if (key == 'i' || key == 'I') playerTargetY -= ySpeed;
+    if (key == 'k' || key == 'K') playerTargetY += ySpeed;
+    if (key == 'j' || key == 'J') playerTargetZ -= zSpeed;
+    if (key == 'm' || key == 'M') playerTargetZ += zSpeed;
+  }
+
+  void cyclePlayer() {
+    playerSide = (playerSide + 1) % 3;
+    // Snap player target to current AI paddle position so there's no jump
+    if (playerSide == 1) { playerTargetY = leftPaddleY;  playerTargetZ = leftPaddleZ; }
+    if (playerSide == 2) { playerTargetY = rightPaddleY; playerTargetZ = rightPaddleZ; }
+  }
+
+  // ── environment floor ─────────────────────────────────────────────────────
 
   void drawEnvironmentFloor(PGraphics pg) {
     float cx   = width / 2.0;
@@ -187,14 +293,12 @@ class TableTennis3DScene extends TableTennisScene {
     pg.pushStyle();
     pg.noStroke();
 
-    // Solid floor slab
     pg.fill(12, 28, 12);
     pg.pushMatrix();
     pg.translate(cx, yBot + 3, 0);
     pg.box(ENV_HW * 2, 6, ENV_HD * 2);
     pg.popMatrix();
 
-    // Grid on floor — drawn as 3D lines
     pg.noLights();
     pg.stroke(0, 90, 0, 90);
     pg.strokeWeight(1);
@@ -211,68 +315,137 @@ class TableTennis3DScene extends TableTennisScene {
     pg.popStyle();
   }
 
-  void drawEnvironmentWalls(PGraphics pg) {
+  // ── environment walls (expanded + animated) ───────────────────────────────
+
+  void drawEnvironmentWalls(PGraphics pg, float bass, float mid) {
     float cx   = width / 2.0;
     float yTop = ENV_TOP;
     float yBot = tableY + ENV_BOT_OFFSET;
+    float roomH = yBot - yTop;
     float xL   = cx - ENV_HW;
     float xR   = cx + ENV_HW;
-    float zN   =  ENV_HD;   // near (toward viewer at +Z)
-    float zF   = -ENV_HD;   // far
+    float zN   =  ENV_HD;
+    float zF   = -ENV_HD;
 
     pg.pushStyle();
     pg.noStroke();
     pg.noLights();
+
+    // ── Base semi-transparent walls ───────────────────────────────────────────
     pg.blendMode(ADD);
+    pg.fill(30, 60, 100, 14);
 
-    // Four side walls — very faint blue tint
-    pg.fill(30, 60, 100, 18);
-
-    // Near wall
     pg.beginShape(QUADS);
     pg.vertex(xL, yTop, zN); pg.vertex(xR, yTop, zN);
     pg.vertex(xR, yBot, zN); pg.vertex(xL, yBot, zN);
     pg.endShape();
 
-    // Far wall
     pg.beginShape(QUADS);
     pg.vertex(xL, yTop, zF); pg.vertex(xR, yTop, zF);
     pg.vertex(xR, yBot, zF); pg.vertex(xL, yBot, zF);
     pg.endShape();
 
-    // Left wall
     pg.beginShape(QUADS);
     pg.vertex(xL, yTop, zF); pg.vertex(xL, yTop, zN);
     pg.vertex(xL, yBot, zN); pg.vertex(xL, yBot, zF);
     pg.endShape();
 
-    // Right wall
     pg.beginShape(QUADS);
     pg.vertex(xR, yTop, zF); pg.vertex(xR, yTop, zN);
     pg.vertex(xR, yBot, zN); pg.vertex(xR, yBot, zF);
     pg.endShape();
 
-    // Ceiling — even fainter
-    pg.fill(20, 40, 70, 10);
+    pg.fill(15, 35, 60, 9);
     pg.beginShape(QUADS);
     pg.vertex(xL, yTop, zF); pg.vertex(xR, yTop, zF);
     pg.vertex(xR, yTop, zN); pg.vertex(xL, yTop, zN);
     pg.endShape();
 
-    // Edge lines — slightly brighter so the box reads as a solid structure
-    pg.stroke(60, 120, 200, 55);
+    // ── Animated scan ring (moves down the walls over time) ──────────────────
+    // Position oscillates based on sceneTime
+    float scanFrac  = (sceneTime * 0.18) % 1.0;
+    float scanY     = yTop + roomH * scanFrac;
+    float scanBand  = 18 + bassSmooth * 45;
+    float scanAlpha = 22 + bassSmooth * 60;
+
+    pg.colorMode(HSB, 360, 255, 255, 255);
+    // Slow hue drift — 8°/sec feels smooth without flickering
+    float scanHue = (sceneTime * 8) % 360;
+    pg.fill((int)scanHue, 200, 255, (int)scanAlpha);
+
+    // Near + far wall horizontal band
+    pg.beginShape(QUADS);
+    pg.vertex(xL, scanY - scanBand, zN); pg.vertex(xR, scanY - scanBand, zN);
+    pg.vertex(xR, scanY + scanBand, zN); pg.vertex(xL, scanY + scanBand, zN);
+    pg.endShape();
+    pg.beginShape(QUADS);
+    pg.vertex(xL, scanY - scanBand, zF); pg.vertex(xR, scanY - scanBand, zF);
+    pg.vertex(xR, scanY + scanBand, zF); pg.vertex(xL, scanY + scanBand, zF);
+    pg.endShape();
+    // Side walls
+    pg.beginShape(QUADS);
+    pg.vertex(xL, scanY - scanBand, zF); pg.vertex(xL, scanY - scanBand, zN);
+    pg.vertex(xL, scanY + scanBand, zN); pg.vertex(xL, scanY + scanBand, zF);
+    pg.endShape();
+    pg.beginShape(QUADS);
+    pg.vertex(xR, scanY - scanBand, zF); pg.vertex(xR, scanY - scanBand, zN);
+    pg.vertex(xR, scanY + scanBand, zN); pg.vertex(xR, scanY + scanBand, zF);
+    pg.endShape();
+
+    // ── Vertical neon bars on walls (pulse with bass) ──────────────────────
+    // Evenly spaced bars on near/far walls; colour shifts with time
+    float barStep = ENV_HW * 2 / 7.0;
+    for (int bi = 0; bi <= 7; bi++) {
+      float bx   = xL + bi * barStep;
+      float bHue = (scanHue + bi * 50) % 360;
+      float bAlpha = 22 + bassSmooth * 70;
+      float bWidth = 4 + bassSmooth * 18;
+
+      pg.fill((int)bHue, 220, 255, (int)bAlpha);
+      // Near wall bar
+      pg.beginShape(QUADS);
+      pg.vertex(bx - bWidth, yTop, zN); pg.vertex(bx + bWidth, yTop, zN);
+      pg.vertex(bx + bWidth, yBot, zN); pg.vertex(bx - bWidth, yBot, zN);
+      pg.endShape();
+      // Far wall bar
+      pg.beginShape(QUADS);
+      pg.vertex(bx - bWidth, yTop, zF); pg.vertex(bx + bWidth, yTop, zF);
+      pg.vertex(bx + bWidth, yBot, zF); pg.vertex(bx - bWidth, yBot, zF);
+      pg.endShape();
+    }
+
+    // Horizontal bars on side walls
+    float hBarStep = ENV_HD * 2 / 5.0;
+    for (int bi = 0; bi <= 5; bi++) {
+      float bz   = zF + bi * hBarStep;
+      float bHue = (scanHue + bi * 65 + 120) % 360;
+      float bAlpha = 18 + bassSmooth * 55;
+      float bWidth = 4 + bassSmooth * 14;
+
+      pg.fill((int)bHue, 210, 255, (int)bAlpha);
+      pg.beginShape(QUADS);
+      pg.vertex(xL, yTop, bz - bWidth); pg.vertex(xL, yTop, bz + bWidth);
+      pg.vertex(xL, yBot, bz + bWidth); pg.vertex(xL, yBot, bz - bWidth);
+      pg.endShape();
+      pg.beginShape(QUADS);
+      pg.vertex(xR, yTop, bz - bWidth); pg.vertex(xR, yTop, bz + bWidth);
+      pg.vertex(xR, yBot, bz + bWidth); pg.vertex(xR, yBot, bz - bWidth);
+      pg.endShape();
+    }
+
+    pg.colorMode(RGB, 255);
+
+    // ── Structural edge lines ─────────────────────────────────────────────────
+    pg.stroke(60, 120, 200, 45);
     pg.strokeWeight(1.5);
-    // Vertical edges
     pg.line(xL, yTop, zN,  xL, yBot, zN);
     pg.line(xR, yTop, zN,  xR, yBot, zN);
     pg.line(xL, yTop, zF,  xL, yBot, zF);
     pg.line(xR, yTop, zF,  xR, yBot, zF);
-    // Top edges
     pg.line(xL, yTop, zN,  xR, yTop, zN);
     pg.line(xL, yTop, zF,  xR, yTop, zF);
     pg.line(xL, yTop, zF,  xL, yTop, zN);
     pg.line(xR, yTop, zF,  xR, yTop, zN);
-    // Bottom edges
     pg.line(xL, yBot, zN,  xR, yBot, zN);
     pg.line(xL, yBot, zF,  xR, yBot, zF);
     pg.line(xL, yBot, zF,  xL, yBot, zN);
@@ -295,14 +468,12 @@ class TableTennis3DScene extends TableTennisScene {
     pg.pushStyle();
     pg.noStroke();
 
-    // Main surface
     pg.fill(0, 110, 0);
     pg.pushMatrix();
     pg.translate(tx, tableY + th / 2.0, 0);
     pg.box(tw, th, TABLE_DEPTH);
     pg.popMatrix();
 
-    // Side frame rails
     pg.fill(0, 75, 0);
     pg.pushMatrix();
     pg.translate(tx - tw / 2.0, tableY + th / 2.0, 0);
@@ -313,30 +484,24 @@ class TableTennis3DScene extends TableTennisScene {
     pg.box(12, th + 4, TABLE_DEPTH + 4);
     pg.popMatrix();
 
-    // White line markings — drawn without lights so they read bright white
     pg.noLights();
     pg.fill(255, 255, 255, 220);
-    // Left edge line
     pg.pushMatrix();
     pg.translate(tx - tw / 2.0, tableY - 1, 0);
     pg.box(3, 3, TABLE_DEPTH);
     pg.popMatrix();
-    // Right edge line
     pg.pushMatrix();
     pg.translate(tx + tw / 2.0, tableY - 1, 0);
     pg.box(3, 3, TABLE_DEPTH);
     pg.popMatrix();
-    // Near end line
     pg.pushMatrix();
     pg.translate(tx, tableY - 1, -halfD);
     pg.box(tw, 3, 3);
     pg.popMatrix();
-    // Far end line
     pg.pushMatrix();
     pg.translate(tx, tableY - 1, halfD);
     pg.box(tw, 3, 3);
     pg.popMatrix();
-    // Centre line — runs the full Z length, prominent white
     pg.fill(255, 255, 255, 255);
     pg.pushMatrix();
     pg.translate(tx, tableY - 2, 0);
@@ -344,13 +509,11 @@ class TableTennis3DScene extends TableTennisScene {
     pg.popMatrix();
     pg.lights();
 
-    // Net — spanning full table depth
     pg.fill(230, 230, 230, 220);
     pg.pushMatrix();
     pg.translate(tx, tableY - NET_H / 2.0, 0);
     pg.box(6, NET_H, TABLE_DEPTH + 16);
     pg.popMatrix();
-    // Net posts
     pg.fill(160, 160, 160);
     pg.pushMatrix();
     pg.translate(tx, tableY - NET_H / 2.0, -(halfD + 8));
@@ -364,7 +527,7 @@ class TableTennis3DScene extends TableTennisScene {
     pg.popStyle();
   }
 
-  // ── 3D paddles (rackets) ──────────────────────────────────────────────────
+  // ── 3D paddles ────────────────────────────────────────────────────────────
 
   void drawPaddles(PGraphics pg) {
     float lx      = leftPaddleX  + leftLungeX;
@@ -372,14 +535,13 @@ class TableTennis3DScene extends TableTennisScene {
     float breathe = bassSmooth * 18;
     float lh      = PADDLE_H + breathe;
     float rh      = PADDLE_H + breathe;
-    float faceR   = PADDLE_Z * 0.46 + breathe * 0.25;   // oval radius breathes with bass
+    float faceR   = PADDLE_Z * 0.46 + breathe * 0.25;
     float lpz = leftPaddleZ;
     float rpz = rightPaddleZ;
 
     pg.pushStyle();
     pg.noStroke();
 
-    // ── Beat-glow aura on the receiving paddle ────────────────────────────
     if (beatGlow > 0.05) {
       boolean leftActive = ballVX < 0;
       float ax = leftActive ? lx : rx;
@@ -404,7 +566,6 @@ class TableTennis3DScene extends TableTennisScene {
       pg.lights();
     }
 
-    // ── Power-shot burst ─────────────────────────────────────────────────
     if (powerFlash > 0.05) {
       pg.noLights();
       pg.blendMode(ADD);
@@ -416,7 +577,6 @@ class TableTennis3DScene extends TableTennisScene {
       pg.lights();
     }
 
-    // ── Impact flash ─────────────────────────────────────────────────────
     if (impactFlash > 0.05) {
       pg.noLights();
       pg.fill(255, 255, 255, (int)(impactFlash * 90));
@@ -425,42 +585,27 @@ class TableTennis3DScene extends TableTennisScene {
       pg.lights();
     }
 
-    // ── Left racket — red face ────────────────────────────────────────────
     pg.fill(200, 35, 35);
     drawRacket(pg, lx, leftPaddleY, lpz, faceR);
 
-    // ── Right racket — blue face ──────────────────────────────────────────
     pg.fill(35, 35, 200);
     drawRacket(pg, rx, rightPaddleY, rpz, faceR);
-
-    // ── Serve indicator ───────────────────────────────────────────────────
-    pg.noLights();
-    pg.fill(255, 220, 0, 200);
-    pg.pushMatrix();
-    pg.translate(leftServes ? lx : rx, tableY - 160, leftServes ? lpz : rpz);
-    pg.sphere(9);
-    pg.popMatrix();
-    pg.lights();
 
     pg.popStyle();
   }
 
-  // Draws one racket at (px, py, 0): oval face (flattened sphere) + wooden handle.
-  // Caller sets pg.fill() for the face colour before calling.
   void drawRacket(PGraphics pg, float px, float py, float pz, float faceR) {
     float faceY   = py - PADDLE_H * 0.08;
     float handleH = PADDLE_H * 0.50;
     float handleW = PADDLE_Z * 0.21;
     float handleY = faceY + faceR + handleH * 0.52 + 3;
 
-    // Oval face — scale a sphere to make it thin in X
     pg.pushMatrix();
     pg.translate(px, faceY, pz);
     pg.scale(PADDLE_D * 0.5 / faceR, 1.0, 1.0);
     pg.sphere(faceR);
     pg.popMatrix();
 
-    // Handle — wood grain colour
     pg.fill(135, 78, 28);
     pg.pushMatrix();
     pg.translate(px, handleY, pz);
@@ -472,6 +617,25 @@ class TableTennis3DScene extends TableTennisScene {
 
   void drawBall(PGraphics pg) {
     pg.pushStyle();
+
+    // ── Shadow on table surface — shows exact X/Z position ───────────────────
+    // Scales down as ball rises; disappears above roughly 3× ball radius off table.
+    float ballAbove = tableY - ballY;   // >0 means ball is above table (Y goes down)
+    if (ballAbove > 0 && ballAbove < 500) {
+      float shadowFade = max(0, 1.0 - ballAbove / 400.0);
+      float shadowR    = BALL_RADIUS * (0.4 + shadowFade * 0.6);
+      pg.noLights();
+      pg.blendMode(BLEND);
+      pg.noStroke();
+      pg.fill(0, 0, 0, (int)(shadowFade * 110));
+      pg.pushMatrix();
+      pg.translate(ballX, tableY - 1, ballZ);
+      pg.rotateX(HALF_PI);
+      pg.ellipse(0, 0, shadowR * 2, shadowR * 2);
+      pg.popMatrix();
+      pg.lights();
+    }
+
     pg.colorMode(HSB, 360, 255, 255, 255);
     pg.noStroke();
 
@@ -498,37 +662,7 @@ class TableTennis3DScene extends TableTennisScene {
     pg.popStyle();
   }
 
-  // ── camera control ───────────────────────────────────────────────────────
-
-  // Left stick Y → zoom.  Right stick XY → orbit azimuth / elevation.
-  // X/Y buttons → ball speed (inherited behaviour kept on those buttons).
-  void applyController(Controller c) {
-    float ly = map(c.ly, 0, height, -1, 1);
-    if (abs(ly) > 0.15) camRadius = constrain(camRadius + ly * 12, 350, 2200);
-
-    float rx = map(c.rx, 0, width,  -1, 1);
-    float ry = map(c.ry, 0, height, -1, 1);
-    if (abs(rx) > 0.15) camAzim += rx * 0.030;
-    if (abs(ry) > 0.15) camElev  = constrain(camElev + ry * 0.020, 0.08, PI / 2 - 0.05);
-
-    // Speed from parent mapping (X=slower, Y=faster)
-    if (c.x_just_pressed) adjustSpeed(-0.1);
-    if (c.y_just_pressed) adjustSpeed( 0.1);
-  }
-
-  // a/d → orbit left/right  |  w/e → tilt up/down  |  z/x → zoom
-  // All other keys forwarded to parent (speed ,/. gravity +/- magnus [/])
-  void handleKey(char k) {
-    if      (k == 'a' || k == 'A') camAzim -= 0.12;
-    else if (k == 'd' || k == 'D') camAzim += 0.12;
-    else if (k == 'w' || k == 'W') camElev  = constrain(camElev + 0.10, 0.08, PI / 2 - 0.05);
-    else if (k == 'e' || k == 'E') camElev  = constrain(camElev - 0.10, 0.08, PI / 2 - 0.05);
-    else if (k == 'z' || k == 'Z') camRadius = constrain(camRadius - 80, 350, 2200);
-    else if (k == 'x' || k == 'X') camRadius = constrain(camRadius + 80, 350, 2200);
-    else super.handleKey(k);
-  }
-
-  // ── 3D trail (uses trail3D which has real Z values) ───────────────────────
+  // ── 3D trail ──────────────────────────────────────────────────────────────
 
   void drawTrail(PGraphics pg) {
     if (trail3D.size() < 2) return;
@@ -547,6 +681,83 @@ class TableTennis3DScene extends TableTennisScene {
     }
     pg.lights();
     pg.colorMode(RGB, 255);
+    pg.popStyle();
+  }
+
+  // ── camera control ────────────────────────────────────────────────────────
+
+  void applyController(Controller c) {
+    float lxN = map(c.lx, 0, width,  -1, 1);
+    float lyN = map(c.ly, 0, height, -1, 1);
+
+    if (playerSide > 0) {
+      // Left stick → move player paddle
+      float yMin = PADDLE_H / 2;
+      float yMax = tableY - PADDLE_H / 2 - 4;
+      float zLim = TABLE_DEPTH / 2.0 - PADDLE_Z / 2.0;
+      if (abs(lyN) > 0.10) playerTargetY = constrain(playerTargetY + lyN * 8, yMin, yMax);
+      if (abs(lxN) > 0.10) playerTargetZ = constrain(playerTargetZ + lxN * 7, -zLim, zLim);
+    } else {
+      // Left stick Y → camera zoom (only in AI mode)
+      if (abs(lyN) > 0.15) camRadius = constrain(camRadius + lyN * 12, 350, 2200);
+    }
+
+    // Right stick → always orbits camera
+    float rxN = map(c.rx, 0, width,  -1, 1);
+    float ryN = map(c.ry, 0, height, -1, 1);
+    if (abs(rxN) > 0.15) camAzim += rxN * 0.030;
+    if (abs(ryN) > 0.15) camElev  = constrain(camElev + ryN * 0.020, 0.08, PI / 2 - 0.05);
+
+    if (c.x_just_pressed) adjustSpeed(-0.1);
+    if (c.y_just_pressed) adjustSpeed( 0.1);
+    if (c.b_just_pressed) cyclePlayer();
+
+    // D-pad L/R → cycle shader style
+    if (c.dpad_left_just_pressed)  cycleShader(-1);
+    if (c.dpad_right_just_pressed) cycleShader( 1);
+  }
+
+  // a/d → orbit  |  w/e → tilt  |  z/x → zoom
+  // f → cycle FX shader  |  v → cycle player control
+  // i/k → paddle up/down (player mode)  |  j/m → paddle Z depth (player mode)
+  void handleKey(char k) {
+    if      (k == 'a' || k == 'A') camAzim -= 0.12;
+    else if (k == 'd' || k == 'D') camAzim += 0.12;
+    else if (k == 'w' || k == 'W') camElev  = constrain(camElev + 0.10, 0.08, PI / 2 - 0.05);
+    else if (k == 'e' || k == 'E') camElev  = constrain(camElev - 0.10, 0.08, PI / 2 - 0.05);
+    else if (k == 'z' || k == 'Z') camRadius = constrain(camRadius - 80, 350, 2200);
+    else if (k == 'x' || k == 'X') camRadius = constrain(camRadius + 80, 350, 2200);
+    else if (k == 'f' || k == 'F') cycleShader(1);
+    else if (k == 'v' || k == 'V') cyclePlayer();
+    else super.handleKey(k);
+  }
+
+  void cycleShader(int dir) {
+    shaderStyle = (shaderStyle + dir + STYLE_NAMES.length) % STYLE_NAMES.length;
+  }
+
+  // ── HUD (override to add shader style line) ───────────────────────────────
+
+  void drawHUD(PGraphics pg) {
+    String sp = spin > 0.05 ? "topspin" : spin < -0.05 ? "backspin" : "flat";
+    String[] playerLabels = {"AI vs AI", "YOU (left/red)", "YOU (right/blue)"};
+    pg.pushStyle();
+    float ts = 11 * uiScale(), lh = ts * 1.3, mg = 4 * uiScale();
+    pg.fill(0, 150); pg.noStroke(); pg.rectMode(CORNER);
+    pg.rect(8, 8, 270 * uiScale(), mg + lh * 8);
+    pg.fill(255); pg.textSize(ts); pg.textAlign(LEFT, TOP);
+    pg.text("Table Tennis 3D",                                   12, 8 + mg);
+    pg.text("Spin: " + sp + " (" + nf(spin,1,2) + ")",           12, 8 + mg + lh);
+    pg.text("Gravity: " + nf(gravity,1,2) + "  (+/-)",            12, 8 + mg + lh*2);
+    pg.text("Magnus: " + nf(magnusStrength,1,3) + "  ([/])",      12, 8 + mg + lh*3);
+    pg.text("Speed: " + nf(speedMult,1,1) + "x  (,/.)",           12, 8 + mg + lh*4);
+    pg.text("Cam: WASD/EZ or R-stick",                            12, 8 + mg + lh*5);
+    pg.fill(80, 255, 180);
+    pg.text("FX: " + STYLE_NAMES[shaderStyle] + "  (F / D-pad)",  12, 8 + mg + lh*6);
+    // Player status — highlight when human-controlled
+    if (playerSide == 0) { pg.fill(180, 180, 180); }
+    else                  { pg.fill(255, 220, 60); }
+    pg.text("Player: " + playerLabels[playerSide] + "  (V / B)",  12, 8 + mg + lh*7);
     pg.popStyle();
   }
 }

--- a/Music_Visualizer_CK/TableTennisScene.pde
+++ b/Music_Visualizer_CK/TableTennisScene.pde
@@ -218,22 +218,31 @@ class TableTennisScene implements IScene {
     float xMargin = PADDLE_W * 2;
 
     if (ballVX < 0) {
-      // Ball heading left — right paddle rests, left paddle tracks
+      // Ball heading left — right paddle rests
       rightTargetX = rightHomeX;
       rightTargetY = constrain(restY, yMin, yMax);
-      // Always retreat to behind home — ball is coming toward you, moving
-      // forward causes the ball to chip over the paddle edge
-      leftTargetX = leftHomeX - 20;
-      float t = abs(ballX - leftPaddleX) / max(abs(ballVX), 0.5);
-      leftTargetY = constrain(predictBallY(t) + leftMissOffset, yMin, yMax);
+      leftTargetX  = leftHomeX - 20;
+      // Left paddle only tracks AFTER ball has bounced on the left side.
+      // lastBounceSide == -1 means it already landed there — legal to return.
+      // If lastBounceSide is 0 or 1 the ball hasn't touched left's court yet — wait.
+      if (lastBounceSide == -1) {
+        float t = abs(ballX - leftPaddleX) / max(abs(ballVX), 0.5);
+        leftTargetY = constrain(predictBallY(t) + leftMissOffset, yMin, yMax);
+      } else {
+        leftTargetY = constrain(restY, yMin, yMax);
+      }
     } else {
-      // Ball heading right — left paddle rests, right paddle tracks
-      leftTargetX = leftHomeX;
-      leftTargetY = constrain(restY, yMin, yMax);
-      // Always retreat to behind home — ball is coming toward you
+      // Ball heading right — left paddle rests
+      leftTargetX  = leftHomeX;
+      leftTargetY  = constrain(restY, yMin, yMax);
       rightTargetX = rightHomeX + 20;
-      float t = abs(rightPaddleX - ballX) / max(abs(ballVX), 0.5);
-      rightTargetY = constrain(predictBallY(t) + rightMissOffset, yMin, yMax);
+      // Right paddle only tracks AFTER ball has bounced on the right side.
+      if (lastBounceSide == 1) {
+        float t = abs(rightPaddleX - ballX) / max(abs(ballVX), 0.5);
+        rightTargetY = constrain(predictBallY(t) + rightMissOffset, yMin, yMax);
+      } else {
+        rightTargetY = constrain(restY, yMin, yMax);
+      }
     }
   }
 

--- a/Music_Visualizer_CK/data/tt3d_acid.glsl
+++ b/Music_Visualizer_CK/data/tt3d_acid.glsl
@@ -1,0 +1,58 @@
+/*
+ * tt3d_acid.glsl — Acid Warp post-process for TableTennis3DScene
+ *
+ * UV warping with nested sine waves + hue rotation cycling.
+ * Bass expands the warp amplitude; time drives the rotation speed.
+ *
+ * Uniforms (set each frame from Processing):
+ *   u_time      — accumulated time in seconds
+ *   u_bass      — bass energy, 0..1
+ *   u_intensity — overall effect blend, 0..1
+ */
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+#define PROCESSING_TEXTURE_SHADER
+
+uniform sampler2D texture;
+uniform vec2      texOffset;
+
+varying vec4 vertColor;
+varying vec4 vertTexCoord;
+
+uniform float u_time;
+uniform float u_bass;
+uniform float u_intensity;
+
+// Rodrigues rotation around the achromatic (1,1,1) axis — rotates hue.
+vec3 hueRotate(vec3 col, float angle) {
+    vec3 k = vec3(0.57735);   // normalize(vec3(1))
+    float c = cos(angle);
+    float s = sin(angle);
+    return col * c + cross(k, col) * s + k * dot(k, col) * (1.0 - c);
+}
+
+void main() {
+    vec2 uv = vertTexCoord.st;
+
+    // Two-layer sinusoidal warp — different frequencies & speeds
+    float wAmt = 0.014 * u_intensity * (1.0 + u_bass * 1.4);
+    float wx = sin(uv.y * 11.0 + u_time * 1.3) * wAmt
+             + sin(uv.y *  5.7 + u_time * 0.7) * wAmt * 0.5;
+    float wy = cos(uv.x *  9.5 + u_time * 1.1) * wAmt
+             + cos(uv.x *  4.3 + u_time * 0.9) * wAmt * 0.5;
+
+    vec2 warpedUV = clamp(uv + vec2(wx, wy), 0.001, 0.999);
+    vec4 col = texture2D(texture, warpedUV);
+
+    // Hue cycling driven by time + bass pulse
+    float hueAngle = u_time * 0.5 + u_bass * 0.8;
+    col.rgb = hueRotate(col.rgb, hueAngle * u_intensity);
+
+    // Subtle brightness pulse on beats
+    col.rgb *= 1.0 + u_bass * 0.25 * u_intensity;
+
+    gl_FragColor = col * vertColor;
+}

--- a/Music_Visualizer_CK/data/tt3d_chromatic.glsl
+++ b/Music_Visualizer_CK/data/tt3d_chromatic.glsl
@@ -1,0 +1,72 @@
+/*
+ * tt3d_chromatic.glsl — Chromatic Glitch post-process for TableTennis3DScene
+ *
+ * RGB channel separation + scanlines + occasional glitch band.
+ * Gives a cyberpunk / broken-CRT aesthetic.
+ *
+ * Uniforms:
+ *   u_time      — accumulated time in seconds
+ *   u_bass      — bass energy, 0..1
+ *   u_intensity — overall effect blend, 0..1
+ */
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+#define PROCESSING_TEXTURE_SHADER
+
+uniform sampler2D texture;
+uniform vec2      texOffset;
+
+varying vec4 vertColor;
+varying vec4 vertTexCoord;
+
+uniform float u_time;
+uniform float u_bass;
+uniform float u_intensity;
+
+// Cheap pseudo-random from UV position
+float rand(vec2 co) {
+    return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+    vec2 uv = vertTexCoord.st;
+
+    // ── Chromatic aberration ──────────────────────────────────────────────────
+    // R shifted right, G center, B shifted left — exaggerated by bass
+    float shift = 0.007 * u_intensity * (1.0 + u_bass * 0.8);
+    float r = texture2D(texture, uv + vec2( shift,  shift * 0.3)).r;
+    float g = texture2D(texture, uv).g;
+    float b = texture2D(texture, uv + vec2(-shift, -shift * 0.3)).b;
+
+    // ── Glitch band (horizontal tear) ────────────────────────────────────────
+    // A thin scanline slides down the screen periodically
+    float bandY   = mod(u_time * 0.35, 1.0);
+    float bandDist = abs(uv.y - bandY);
+    if (bandDist < 0.018) {
+        // Inside the glitch band: add horizontal jitter + colour bleed
+        float jitter = (rand(vec2(floor(uv.y * 200.0), u_time)) - 0.5) * 0.025 * u_intensity;
+        r = texture2D(texture, uv + vec2(shift + jitter, 0.0)).r;
+        b = texture2D(texture, uv + vec2(-shift - jitter * 0.5, 0.0)).b;
+        // Slight brightness spike in the band
+        r *= 1.15; g *= 1.1; b *= 1.2;
+    }
+
+    // ── Scanlines ─────────────────────────────────────────────────────────────
+    // Faint horizontal lines like a CRT
+    float scanline = sin(uv.y * 720.0 * 3.14159);
+    float scanAmt  = mix(0.0, 0.09, u_intensity);
+    float scanFactor = 1.0 - (scanline * 0.5 + 0.5) * scanAmt;
+
+    vec4 col = vec4(r, g, b, 1.0);
+    col.rgb  *= scanFactor;
+
+    // ── Cool tint (cyan shadows, warm highlights) ────────────────────────────
+    float lum = dot(col.rgb, vec3(0.299, 0.587, 0.114));
+    vec3 tint = mix(vec3(0.4, 0.7, 1.0), vec3(1.0, 0.9, 0.8), lum);
+    col.rgb = mix(col.rgb, col.rgb * tint, 0.18 * u_intensity);
+
+    gl_FragColor = col * vertColor;
+}

--- a/Music_Visualizer_CK/data/tt3d_neon.glsl
+++ b/Music_Visualizer_CK/data/tt3d_neon.glsl
@@ -1,0 +1,62 @@
+/*
+ * tt3d_neon.glsl — Neon Bloom post-process for TableTennis3DScene
+ *
+ * Extracts bright areas, blurs them into a halo, and adds saturation boost.
+ * Brights glow hard; darks stay dark — neon / arcade aesthetic.
+ *
+ * Uniforms:
+ *   u_bass      — bass energy, 0..1  (expands bloom radius)
+ *   u_intensity — overall effect blend, 0..1
+ */
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+#define PROCESSING_TEXTURE_SHADER
+
+uniform sampler2D texture;
+uniform vec2      texOffset;
+
+varying vec4 vertColor;
+varying vec4 vertTexCoord;
+
+uniform float u_bass;
+uniform float u_intensity;
+
+void main() {
+    vec2 uv  = vertTexCoord.st;
+    vec4 src = texture2D(texture, uv);
+
+    // ── Saturation boost ──────────────────────────────────────────────────────
+    float grey    = dot(src.rgb, vec3(0.299, 0.587, 0.114));
+    float satMult = 1.5 + u_bass * 0.4;
+    vec3  boosted = mix(vec3(grey), src.rgb, satMult);
+
+    // ── 8-tap bloom ring ─────────────────────────────────────────────────────
+    // Only samples that are above threshold contribute; keeps the bloom tight.
+    float bloomR = (2.0 + u_bass * 3.5) * u_intensity;
+    float thresh = 0.30;
+    vec4  bloom  = vec4(0.0);
+    float weight = 0.0;
+
+    for (float a = 0.0; a < 6.28318; a += 0.78540) {   // 8 taps
+        vec2  off = vec2(cos(a), sin(a)) * texOffset * bloomR;
+        vec4  s   = texture2D(texture, uv + off);
+        float lum = dot(s.rgb, vec3(0.299, 0.587, 0.114));
+        float w   = max(0.0, lum - thresh);
+        bloom  += s * w;
+        weight += w;
+    }
+    if (weight > 0.0) bloom /= weight;
+
+    // ── Combine ───────────────────────────────────────────────────────────────
+    vec3 finalRGB = boosted + bloom.rgb * 2.0 * u_intensity;
+
+    // Additive hue tint toward hot colours on bright pixels
+    float brightness = dot(finalRGB, vec3(0.333));
+    vec3  neonHue    = vec3(1.0, 0.2 + u_bass * 0.6, 0.9 - u_bass * 0.3);
+    finalRGB = mix(finalRGB, finalRGB * neonHue, brightness * 0.18 * u_intensity);
+
+    gl_FragColor = vec4(clamp(finalRGB, 0.0, 2.5), src.a) * vertColor;
+}


### PR DESCRIPTION
- 3 post-process shaders (F/D-pad) Warp, Chromatic Glitch, Neon Bloom
- Player can control a paddle (V/B): left stick Y+X = height + Z depth
- Expanded skybox (2x wider/deeper/taller) + animated neon bars + scan ring
- Ball shadow on table surface for depth perception
- Removed orange serve indicator
- Z physics now runs before main physics (fixes one-frame paddle Z lag)
- AI Z tracking uses predicted intercept position, not current ball Z
- TableTennisScene: paddles wait for ball to bounce before tracking (no more volleying)