### PR TITLE
feat(auto-switch): beat-synced scene auto-switcher

### DIFF
--- a/Music_Visualizer_CK/Music_Visualizer_CK.pde
+++ b/Music_Visualizer_CK/Music_Visualizer_CK.pde
@@ -1200,6 +1200,29 @@ void drawCodeOverlay(String[] lines) {
   popStyle();
 }
 
+void drawAutoSwitcherBadge() {
+  String line = autoSwitcher.hudLine();
+  if (line == null) return;
+  pushStyle();
+  textFont(monoFont);
+  float ts = 12 * uiScale();
+  textSize(ts);
+  textAlign(LEFT, TOP);
+  // Fixed width sized for longest possible line ("AUTO FAVS WEIGHTED cd 999s  ").
+  float tw    = textWidth("AUTO FAVS WEIGHTED cd 999s  ");
+  float boxH  = ts + 10;
+  float boxW  = tw + 16;
+  float pad   = 10 * uiScale();
+  float boxX  = width - pad - boxW;
+  float boxY  = height - pad - boxH;
+  noStroke();
+  fill(0, 180);
+  rect(boxX, boxY, boxW, boxH, 4);
+  fill(0, 255, 120);
+  text(line, boxX + 8, boxY + 5);
+  popStyle();
+}
+
 void addFPSToTitleBar() {
   if (frameCount % 100 == 0) {
     surface.setTitle("Music Visualizer CK | fps: " + int(frameRate) + " | scene: " + config.STATE

--- a/Music_Visualizer_CK/src/core/AutoSwitcher.pde
+++ b/Music_Visualizer_CK/src/core/AutoSwitcher.pde
@@ -1,0 +1,129 @@
+// AutoSwitcher — beat-synced auto scene switching on major drops.
+//
+// Gated by dropPredictor: only fires when majorImminentDropFactor crosses
+// a threshold. Has cooldown + recent-history so switches feel deliberate
+// instead of random. Five modes, toggled via L3 / F9, cycled via R3 / Shift+F9.
+
+class AutoSwitcher {
+
+  // ── Modes ─────────────────────────────────────────────────────────────────
+  // (no `static` — Processing classes are inner classes of PApplet)
+  final int MODE_OFF            = 0;
+  final int MODE_FAVS_ONLY      = 1;
+  final int MODE_FAVS_WEIGHTED  = 2;
+  final int MODE_SEQUENTIAL     = 3;
+  final int MODE_RANDOM_ALL     = 4;
+  final int MODE_COUNT          = 5;
+
+  final String[] MODE_LABELS = {
+    "OFF", "FAVS ONLY", "FAVS WEIGHTED", "SEQUENTIAL", "RANDOM"
+  };
+
+  // ── Tuning ────────────────────────────────────────────────────────────────
+  final float DROP_THRESHOLD   = 0.55;    // majorImminentDropFactor gate
+  final int   COOLDOWN_FRAMES  = 60 * 60; // 60s between switches
+  final int   HISTORY_SIZE     = 3;       // avoid last N scenes on pick
+  final int   FAV_WEIGHT       = 3;       // weighted mode multiplier
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  int     mode            = MODE_FAVS_WEIGHTED; // default when enabled
+  boolean enabled         = false;
+  int     lastSwitchFrame = -9999;
+  java.util.Deque<Integer> recent = new java.util.ArrayDeque<Integer>();
+
+  // ── Public API ────────────────────────────────────────────────────────────
+  void toggleEnabled() {
+    enabled = !enabled;
+    if (enabled) lastSwitchFrame = frameCount; // grace period after enabling
+  }
+
+  void cycleMode() {
+    mode = (mode + 1) % MODE_COUNT;
+    if (mode == MODE_OFF) mode = MODE_FAVS_ONLY; // OFF is handled by enabled flag
+  }
+
+  // Called every logical tick. Triggers switchScene() when drop detected.
+  void tick() {
+    if (!enabled) return;
+    if (dropPredictor == null || !dropPredictor.isReady) return;
+    if (frameCount - lastSwitchFrame < COOLDOWN_FRAMES) return;
+    if (pendingScene >= 0) return; // switch already queued
+
+    float imminence = dropPredictor.majorImminentDropFactor(audio.player.position(), 4.0);
+    if (imminence < DROP_THRESHOLD) return;
+
+    int next = pickNext();
+    if (next < 0 || next == config.STATE) return;
+
+    switchScene(next);
+    lastSwitchFrame = frameCount;
+    recent.addLast(next);
+    while (recent.size() > HISTORY_SIZE) recent.removeFirst();
+  }
+
+  // ── Scene picking ─────────────────────────────────────────────────────────
+  int pickNext() {
+    ArrayList<Integer> order = sceneSwitcher.activeOrder;
+    HashSet<Integer> favs    = sceneSwitcher.favourites;
+    if (order.isEmpty()) return -1;
+
+    switch (mode) {
+      case MODE_SEQUENTIAL: {
+        int next = sceneSwitcher.nextScene(config.STATE);
+        // Skip blacklisted
+        int guard = 0;
+        while (sceneGuard != null && sceneGuard.isBlacklisted(next) && guard++ < order.size()) {
+          next = sceneSwitcher.nextScene(next);
+        }
+        return next;
+      }
+      case MODE_FAVS_ONLY: {
+        ArrayList<Integer> pool = new ArrayList<Integer>();
+        for (int s : favs) if (s != config.STATE && !isBlocked(s)) pool.add(s);
+        if (pool.isEmpty()) {
+          // Fallback: any fav except current, ignoring history
+          for (int s : favs) if (s != config.STATE) pool.add(s);
+        }
+        if (pool.isEmpty()) return -1;
+        return pool.get((int) random(pool.size()));
+      }
+      case MODE_FAVS_WEIGHTED: {
+        ArrayList<Integer> pool = new ArrayList<Integer>();
+        for (int s : order) {
+          if (s == config.STATE || isBlocked(s)) continue;
+          int w = favs.contains(s) ? FAV_WEIGHT : 1;
+          for (int i = 0; i < w; i++) pool.add(s);
+        }
+        if (pool.isEmpty()) return -1;
+        return pool.get((int) random(pool.size()));
+      }
+      case MODE_RANDOM_ALL: {
+        ArrayList<Integer> pool = new ArrayList<Integer>();
+        for (int s : order) if (s != config.STATE && !isBlocked(s)) pool.add(s);
+        if (pool.isEmpty()) return -1;
+        return pool.get((int) random(pool.size()));
+      }
+    }
+    return -1;
+  }
+
+  boolean isBlocked(int sceneIdx) {
+    if (sceneGuard != null && sceneGuard.isBlacklisted(sceneIdx)) return true;
+    return recent.contains(sceneIdx);
+  }
+
+  // ── HUD ───────────────────────────────────────────────────────────────────
+  String hudLine() {
+    if (!enabled) return null;
+    int secsLeft = max(0, (COOLDOWN_FRAMES - (frameCount - lastSwitchFrame) + 59) / 60);
+    String label = padRight(MODE_LABELS[mode], 13);
+    String right = (secsLeft > 0) ? ("cd " + nf(secsLeft, 3) + "s  ") : "  READY  ";
+    return "AUTO " + label + right;
+  }
+
+  String padRight(String s, int n) {
+    StringBuilder sb = new StringBuilder(s);
+    while (sb.length() < n) sb.append(' ');
+    return sb.toString();
+  }
+}

--- a/Music_Visualizer_CK/src/scenes/MerkabaStarScene.pde
+++ b/Music_Visualizer_CK/src/scenes/MerkabaStarScene.pde
@@ -98,6 +98,7 @@ class MerkabaStarScene implements IScene {
   // ── IScene lifecycle ───────────────────────────────────────────────────────
   void onEnter() {
     buf = createGraphics(sceneBuffer.width, sceneBuffer.height, P3D);
+    buf.smooth(4);
     camAzim=0.55; camElev=0.30; beatExpand=0;
     rotX=0; rotZ=0; rotPath=0; pathFrames=0;
   }
@@ -149,6 +150,7 @@ class MerkabaStarScene implements IScene {
     if (buf == null || buf.width != pg.width || buf.height != pg.height) {
       if (buf != null) buf.dispose();
       buf = createGraphics(pg.width, pg.height, P3D);
+      buf.smooth(4);
     }
 
     sBass = lerp(sBass, analyzer.bass, 0.07);

--- a/Music_Visualizer_CK/src/scenes/Original3DScene.pde
+++ b/Music_Visualizer_CK/src/scenes/Original3DScene.pde
@@ -51,6 +51,7 @@ class Original3DScene implements IScene {
 
   void onEnter() {
     buf = createGraphics(sceneBuffer.width, sceneBuffer.height, P3D);
+    buf.smooth(4);
     S = min(sceneBuffer.width, sceneBuffer.height) * 0.45;
     diamondDistCenter = S * 0.07;
   }
@@ -92,6 +93,7 @@ class Original3DScene implements IScene {
     if (buf == null || buf.width != pg.width || buf.height != pg.height) {
       if (buf != null) buf.dispose();
       buf = createGraphics(pg.width, pg.height, P3D);
+      buf.smooth(4);
     }
     S = min(buf.width, buf.height) * 0.45;
 

--- a/Music_Visualizer_CK/src/scenes/OriginalScene.pde
+++ b/Music_Visualizer_CK/src/scenes/OriginalScene.pde
@@ -215,6 +215,7 @@ class OriginalScene implements IScene {
       int sq = (int)s1Size;
       if (tunnelBuf == null || tunnelBuf.width != sq) {
         tunnelBuf = createGraphics(sq, sq, P2D);
+        tunnelBuf.smooth(4);
       }
       tunnelBuf.beginDraw();
       tunnel.draw(tunnelBuf, config.TUNNEL_ZOOM_INCREMENT, tunnelTwistOff, 0, sq);

--- a/Music_Visualizer_CK/src/scenes/PentagonalVortexScene.pde
+++ b/Music_Visualizer_CK/src/scenes/PentagonalVortexScene.pde
@@ -83,6 +83,7 @@ class PentagonalVortexScene implements IScene {
   // ── IScene lifecycle ───────────────────────────────────────────────────────
   void onEnter() {
     buf = createGraphics(sceneBuffer.width, sceneBuffer.height, P3D);
+    buf.smooth(4);
     tunnelOffset = 0; hueOffset = 0;
     rotation = 0; wavePhase = 2.0; waveAlpha = 0;
   }
@@ -181,6 +182,7 @@ class PentagonalVortexScene implements IScene {
     if (buf == null || buf.width != pg.width || buf.height != pg.height) {
       if (buf != null) buf.dispose();
       buf = createGraphics(pg.width, pg.height, P3D);
+      buf.smooth(4);
     }
 
     // Scroll — constant speed, no audio speed changes

--- a/Music_Visualizer_CK/src/scenes/TableTennis3DScene.pde
+++ b/Music_Visualizer_CK/src/scenes/TableTennis3DScene.pde
@@ -139,6 +139,7 @@ class TableTennis3DScene extends TableTennisScene {
   void ensureResources(PGraphics pg) {
     if (innerBuf == null || innerBuf.width != pg.width || innerBuf.height != pg.height) {
       innerBuf = createGraphics(pg.width, pg.height, P3D);
+      innerBuf.smooth(4); // MSAA — removes jagged edges on net, table, paddles
     }
     if (acidShader     == null) acidShader     = loadShader("tt3d_acid.glsl");
     if (chromaticShader == null) chromaticShader = loadShader("tt3d_chromatic.glsl");

--- a/Music_Visualizer_CK/src/scenes/TableTennisScene.pde
+++ b/Music_Visualizer_CK/src/scenes/TableTennisScene.pde
@@ -55,8 +55,13 @@ class TableTennisScene implements IScene {
   boolean rallyStarted   = false; // true once the serve has landed on the opponent's side
 
   // serve state machine
-  boolean inServeDrop  = true;   // ball falling toward paddle before being hit
+  boolean inServeDrop  = true;   // ball aloft before being struck (legal toss-up)
   boolean serveBounced = false;  // ball has completed its server-side bounce
+
+  // Post-point pause — lets the viewer breathe before next serve.
+  // Set by awardPoint(); when it hits 0, serve() runs.
+  int pointPauseFrames = 0;
+  final int POINT_PAUSE_FRAMES = 150; // ~2.5s at 60fps
 
   // visual flash on point scored
   float pointFlash  = 0;
@@ -120,13 +125,15 @@ class TableTennisScene implements IScene {
     leftPaddleX  = leftHomeX;  rightPaddleX  = rightHomeX;
     leftTargetX  = leftHomeX;  rightTargetX  = rightHomeX;
 
-    // Ball drops from ~100px above the server's paddle (like a real toss).
-    // It falls under gravity; when it reaches paddle height it auto-fires.
+    // Legal serve: ball rests on server's open palm (just above paddle), then is
+    // tossed straight up. Falls under gravity; when it descends back to paddle
+    // height, the paddle auto-strikes. ITTF requires a visible vertical toss —
+    // no drop-serving.
     float paddleX = leftServes ? leftPaddleX : rightPaddleX;
     ballX  = paddleX;
-    ballY  = tableY - 220;   // above the paddle (which rests at tableY-120)
+    ballY  = tableY - 140;   // just above the paddle (which rests at tableY-120)
     ballVX = leftServes ? 0.01 : -0.01;  // tiny drift so dirSign is correct
-    ballVY = 0;
+    ballVY = -10;            // upward toss → apex ~180px above paddle at g=0.28
     spin   = random(-0.05, 0.05);
     trail.clear();
     impactFlash  = 0;
@@ -292,7 +299,23 @@ class TableTennisScene implements IScene {
   // ── physics ───────────────────────────────────────────────────────────────
 
   void updatePhysics() {
-    // ── Serve drop: ball falls under gravity until it reaches the paddle ──────
+    // ── Post-point pause ──────────────────────────────────────────────────────
+    // Let the ball coast freely (gravity + drag) for a couple seconds after a
+    // point is awarded, then call serve() to set up the next rally. No
+    // collisions or scoring during the pause.
+    if (pointPauseFrames > 0) {
+      pointPauseFrames--;
+      ballVY += gravity;
+      ballVX *= DRAG;
+      ballX  += ballVX;
+      ballY  += ballVY;
+      trail.add(new PVector(ballX, ballY));
+      if (trail.size() > MAX_TRAIL) trail.remove(0);
+      if (pointPauseFrames == 0) serve();
+      return;
+    }
+
+    // ── Serve toss: ball tossed upward, auto-struck as it descends ────────────
     if (inServeDrop) {
       ballVY += gravity;
       ballY  += ballVY;
@@ -319,14 +342,18 @@ class TableTennisScene implements IScene {
 
     // Net collision — block ball if it crosses the centre line below net height.
     // Skip during serve drop (ball is above the table, can't hit the net yet).
+    // Ball body overlaps net if ball-bottom > netTop AND ball-top < tableY.
+    // Previous code used ball-bottom for both checks, leaving a ~BALL_RADIUS gap
+    // of low-altitude balls that passed through the mesh.
     if (!inServeDrop) {
       float netX   = sceneBuffer.width / 2.0;
       float netTop = tableY - NET_H;
-      if (ballY + BALL_RADIUS > netTop && ballY + BALL_RADIUS < tableY) {
+      if (ballY + BALL_RADIUS > netTop && ballY - BALL_RADIUS < tableY) {
         boolean crossedNet = (prevBallX < netX) != (ballX < netX);
         if (crossedNet) {
           ballX  = prevBallX < netX ? netX - BALL_RADIUS - 1 : netX + BALL_RADIUS + 1;
           ballVX *= -0.4;
+          ballVY *= 0.3;
         }
       }
     }
@@ -338,9 +365,9 @@ class TableTennisScene implements IScene {
       ballVX *= 0.96;
       spin   *= 0.76;
       onTableBounce();
-      // onTableBounce may have awarded a point and called serve() — bail out
-      // to avoid the escape-check running on the freshly reset ball position.
-      if (inServeDrop) {
+      // onTableBounce may have awarded a point — bail out so the escape/paddle
+      // checks don't run on a ball whose rally just ended (prevents double-score).
+      if (inServeDrop || pointPauseFrames > 0) {
         trail.add(new PVector(ballX, ballY));
         if (trail.size() > MAX_TRAIL) trail.remove(0);
         return;
@@ -362,9 +389,9 @@ class TableTennisScene implements IScene {
     // Paddle collisions (receiver can't return during serve drop or serve bounce)
     if (!inServeDrop) {
       checkPaddleCollision(true,  leftPaddleX  + leftLungeX,  leftPaddleY);
-      if (inServeDrop) { trail.add(new PVector(ballX, ballY)); if (trail.size() > MAX_TRAIL) trail.remove(0); return; }
+      if (inServeDrop || pointPauseFrames > 0) { trail.add(new PVector(ballX, ballY)); if (trail.size() > MAX_TRAIL) trail.remove(0); return; }
       checkPaddleCollision(false, rightPaddleX - rightLungeX, rightPaddleY);
-      if (inServeDrop) { trail.add(new PVector(ballX, ballY)); if (trail.size() > MAX_TRAIL) trail.remove(0); return; }
+      if (inServeDrop || pointPauseFrames > 0) { trail.add(new PVector(ballX, ballY)); if (trail.size() > MAX_TRAIL) trail.remove(0); return; }
     }
 
     // Ball escaped past a paddle — virtual so 3D subclass can override
@@ -502,7 +529,7 @@ class TableTennisScene implements IScene {
     if (leftWins)  { leftGames++;  logGame(true);  resetGame(); return; }
     if (rightWins) { rightGames++; logGame(false); resetGame(); return; }
 
-    serve();
+    pointPauseFrames = POINT_PAUSE_FRAMES;
   }
 
   void resetGame() {
@@ -513,7 +540,7 @@ class TableTennisScene implements IScene {
     leftServes   = true;
     inServeDrop  = true;
     serveBounced = false;
-    serve();
+    pointPauseFrames = POINT_PAUSE_FRAMES;
   }
 
   // ── score logging ──────────────────────────────────────────────────────────

--- a/Music_Visualizer_CK/src/scenes/TorusKnotScene.pde
+++ b/Music_Visualizer_CK/src/scenes/TorusKnotScene.pde
@@ -67,6 +67,7 @@ class TorusKnotScene implements IScene {
 
   void onEnter() {
     buf = createGraphics(sceneBuffer.width, sceneBuffer.height, P3D);
+    buf.smooth(4);
     rebuildCurve();
   }
 
@@ -167,6 +168,7 @@ class TorusKnotScene implements IScene {
     if (buf == null || buf.width != pg.width || buf.height != pg.height) {
       if (buf != null) buf.dispose();
       buf = createGraphics(pg.width, pg.height, P3D);
+      buf.smooth(4);
     }
 
     // Audio


### PR DESCRIPTION
## Summary
- New `AutoSwitcher` class: triggers scene changes on `dropPredictor` major drops with 60s cooldown and recent-3 history.
- Modes: `FAVS_ONLY`, `FAVS_WEIGHTED` (favs 3× weight), `SEQUENTIAL`, `RANDOM_ALL`. Default on enable: `FAVS_WEIGHTED`.
- Controller: **L3** toggle, **R3** cycle mode. Keyboard: **F9** toggle, **Shift+F9** cycle mode.
- Reuses existing `switchScene()` which already beat-syncs + crossfades.
- Bottom-right HUD badge: `AUTO <MODE>  cd Ns` during cooldown, `READY` when armed. Fixed-width monospace — no jitter.

## Notes
- `b0b4f01` (kaleidoscope rewrite, now on develop) accidentally included the wiring edits (globals, setup, keybinds, tick call, badge call) but **not** the `AutoSwitcher` class file or `drawAutoSwitcherBadge()` function. develop is currently un-compilable on its own — this PR is what makes it build again.

## Test plan
- [ ] `./run.sh` launches without errors
- [ ] Press F9 — badge appears bottom-right with `AUTO FAVS WEIGHTED  cd 060s`
- [ ] Wait 60s, badge flips to `READY`
- [ ] On next major drop, scene auto-switches; cooldown restarts
- [ ] Shift+F9 cycles modes — label updates, width stays constant (no jitter)
- [ ] Controller L3 / R3 do the same
- [ ] Scene switcher favourites (`Tab` → `f`) influence which scenes get picked in FAVS modes